### PR TITLE
Add simple Pirates shooter game

### DIFF
--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -3,7 +3,7 @@
 
 import React from "react";
 import { Container } from "@mui/material";
-import Game from "@/games/warbirds";
+import Game from "@/games/pirates";
 
 export default function Home() {
   return (

--- a/src/games/pirates/components/GameUI.tsx
+++ b/src/games/pirates/components/GameUI.tsx
@@ -1,0 +1,57 @@
+"use client";
+import React from "react";
+import Box from "@mui/material/Box";
+import { MAX_AMMO, DEFAULT_CURSOR } from "../constants";
+
+export interface GameUIProps {
+  score: number;
+  ammo: number;
+  canvasRef: React.RefObject<HTMLCanvasElement>;
+  handleClick: (e: React.MouseEvent) => void;
+  handleContext: (e: React.MouseEvent) => void;
+  getImg: (key: string) => HTMLImageElement | undefined;
+  cursor: string;
+}
+
+export default function GameUI({
+  score,
+  ammo,
+  canvasRef,
+  handleClick,
+  handleContext,
+  getImg,
+  cursor,
+}: GameUIProps) {
+  const bulletSrc = getImg("bulletImg")?.src;
+  return (
+    <Box position="relative" width="100vw" height="100vh">
+      <Box position="absolute" top={16} left={16} display="flex" zIndex={1}>
+        {Array.from({ length: MAX_AMMO }).map((_, i) => (
+          <Box
+            key={i}
+            component="img"
+            src={bulletSrc}
+            width={32}
+            height={32}
+            sx={{ mr: 0.5, opacity: i < ammo ? 1 : 0.3, rotate: "-90deg" }}
+          />
+        ))}
+      </Box>
+      <Box
+        position="absolute"
+        top={16}
+        right={16}
+        zIndex={1}
+        sx={{ fontSize: 32, color: "white", fontWeight: "bold", cursor: DEFAULT_CURSOR }}
+      >
+        Score: {score}
+      </Box>
+      <canvas
+        ref={canvasRef}
+        onClick={handleClick}
+        onContextMenu={handleContext}
+        style={{ width: "100%", height: "100%", cursor }}
+      />
+    </Box>
+  );
+}

--- a/src/games/pirates/components/TitleSplash.tsx
+++ b/src/games/pirates/components/TitleSplash.tsx
@@ -1,0 +1,35 @@
+"use client";
+import React from "react";
+import Box from "@mui/material/Box";
+import { SKY_COLOR, DEFAULT_CURSOR } from "../constants";
+
+export interface TitleSplashProps {
+  onStart: () => void;
+}
+
+export default function TitleSplash({ onStart }: TitleSplashProps) {
+  return (
+    <Box
+      onClick={onStart}
+      position="relative"
+      width="100vw"
+      height="100vh"
+      sx={{ backgroundColor: SKY_COLOR, cursor: DEFAULT_CURSOR }}
+      display="flex"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <Box
+        component="img"
+        src="/assets/pirates/PNG/Retina/Ships/ship (1).png"
+        alt="Pirate Ship"
+        sx={{ width: 300, height: "auto" }}
+      />
+      <Box sx={{ mt: 2, fontSize: 48, color: "white", fontWeight: "bold" }}>
+        Pirate Shooter
+      </Box>
+      <Box sx={{ mt: 1, fontSize: 24, color: "white" }}>Click to start</Box>
+    </Box>
+  );
+}

--- a/src/games/pirates/constants.ts
+++ b/src/games/pirates/constants.ts
@@ -1,0 +1,6 @@
+export const MAX_AMMO = 6;
+export const SKY_COLOR = "#79a8d1";
+export const DEFAULT_CURSOR =
+  "url('/assets/shooting-gallery/PNG/HUD/crosshair_red_small.png') 16 16, auto";
+export const SHOT_CURSOR =
+  "url('/assets/shooting-gallery/PNG/Objects/shot_brown_large.png') 16 16, auto";

--- a/src/games/pirates/hooks/useGameAssets.ts
+++ b/src/games/pirates/hooks/useGameAssets.ts
@@ -1,0 +1,30 @@
+"use client";
+import { useEffect, useRef, useCallback, useState } from "react";
+
+export function useGameAssets() {
+  const [ready, setReady] = useState(false);
+  const assets = useRef<Record<string, HTMLImageElement>>({});
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const load = (src: string) => {
+      const img = new window.Image();
+      img.src = src;
+      return img;
+    };
+    assets.current.shipImg = load(
+      "/assets/pirates/PNG/Retina/Ships/ship (1).png"
+    );
+    assets.current.bulletImg = load(
+      "/assets/tanks/PNG/Retina/tank_bullet5.png"
+    );
+    setReady(true);
+  }, []);
+
+  const getImg = useCallback(
+    (key: string) => assets.current[key],
+    []
+  );
+
+  return { ready, getImg };
+}

--- a/src/games/pirates/hooks/useGameAudio.ts
+++ b/src/games/pirates/hooks/useGameAudio.ts
@@ -1,0 +1,24 @@
+"use client";
+import { useAudio } from "@/hooks/useAudio";
+import { useMemo, useCallback } from "react";
+
+export function useGameAudio() {
+  const shot = useAudio("/audio/laser4.ogg");
+  const reload = useAudio("/audio/scratch_003.ogg");
+  const hit = useAudio("/audio/explosionCrunch_001.ogg");
+
+  const refs = useMemo(() => ({ shot, reload, hit }), [shot, reload, hit]);
+
+  const play = useCallback(
+    (key: keyof typeof refs) => {
+      const ref = refs[key];
+      if (ref.current) {
+        ref.current.currentTime = 0;
+        ref.current.play();
+      }
+    },
+    [refs]
+  );
+
+  return { play };
+}

--- a/src/games/pirates/hooks/useGameEngine.ts
+++ b/src/games/pirates/hooks/useGameEngine.ts
@@ -1,0 +1,108 @@
+"use client";
+import { useRef, useState, useEffect, useCallback } from "react";
+import { useWindowSize } from "@/hooks/useWindowSize";
+import { useGameAssets } from "./useGameAssets";
+import { useGameAudio } from "./useGameAudio";
+import {
+  MAX_AMMO,
+  SKY_COLOR,
+  DEFAULT_CURSOR,
+  SHOT_CURSOR,
+} from "../constants";
+
+export function useGameEngine() {
+  const dims = useWindowSize();
+  const { ready, getImg } = useGameAssets();
+  const audio = useGameAudio();
+
+  const [phase, setPhase] = useState<"title" | "playing">("title");
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [score, setScore] = useState(0);
+  const [ammo, setAmmo] = useState(MAX_AMMO);
+  const [cursor, setCursor] = useState(DEFAULT_CURSOR);
+  const ship = useRef({ x: 0, y: 0, speed: 2, w: 0, h: 0 });
+
+  const spawnShip = useCallback(() => {
+    const img = getImg("shipImg") as HTMLImageElement | undefined;
+    if (!img) return;
+    ship.current.w = img.width;
+    ship.current.h = img.height;
+    ship.current.x = dims.width;
+    ship.current.y = Math.random() * (dims.height - img.height);
+    ship.current.speed = 2 + Math.random() * 2;
+  }, [dims.width, dims.height, getImg]);
+
+  useEffect(() => {
+    if (!ready || phase !== "playing") return;
+    spawnShip();
+    const ctx = canvasRef.current?.getContext("2d");
+    if (!ctx) return;
+
+    let frame: number;
+    const loop = () => {
+      frame = requestAnimationFrame(loop);
+      ctx.fillStyle = SKY_COLOR;
+      ctx.fillRect(0, 0, dims.width, dims.height);
+      ship.current.x -= ship.current.speed;
+      if (ship.current.x + ship.current.w < 0) spawnShip();
+      const img = getImg("shipImg") as HTMLImageElement | undefined;
+      if (img) ctx.drawImage(img, ship.current.x, ship.current.y);
+    };
+    loop();
+    return () => cancelAnimationFrame(frame);
+  }, [ready, phase, dims.width, dims.height, spawnShip, getImg]);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (phase !== "playing" || ammo <= 0) return;
+      const rect = canvasRef.current!.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      setAmmo((a) => a - 1);
+      setCursor(SHOT_CURSOR);
+      setTimeout(() => setCursor(DEFAULT_CURSOR), 100);
+      audio.play("shot");
+      if (
+        x >= ship.current.x &&
+        x <= ship.current.x + ship.current.w &&
+        y >= ship.current.y &&
+        y <= ship.current.y + ship.current.h
+      ) {
+        setScore((s) => s + 100);
+        audio.play("hit");
+        spawnShip();
+      }
+    },
+    [phase, ammo, audio, spawnShip]
+  );
+
+  const handleContext = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      if (phase !== "playing") return;
+      if (ammo < MAX_AMMO) {
+        setAmmo(MAX_AMMO);
+        audio.play("reload");
+      }
+    },
+    [phase, ammo, audio]
+  );
+
+  const startGame = useCallback(() => {
+    setScore(0);
+    setAmmo(MAX_AMMO);
+    setPhase("playing");
+  }, []);
+
+  return {
+    phase,
+    startGame,
+    canvasRef,
+    handleClick,
+    handleContext,
+    ammo,
+    score,
+    getImg,
+    cursor,
+  };
+}

--- a/src/games/pirates/index.tsx
+++ b/src/games/pirates/index.tsx
@@ -1,0 +1,36 @@
+"use client";
+import React from "react";
+import { DEFAULT_CURSOR } from "./constants";
+import TitleSplash from "./components/TitleSplash";
+import GameUI from "./components/GameUI";
+import { useGameEngine } from "./hooks/useGameEngine";
+
+export default function Game() {
+  const {
+    phase,
+    startGame,
+    canvasRef,
+    handleClick,
+    handleContext,
+    ammo,
+    score,
+    getImg,
+    cursor,
+  } = useGameEngine();
+
+  if (phase === "title") {
+    return <TitleSplash onStart={startGame} />;
+  }
+
+  return (
+    <GameUI
+      score={score}
+      ammo={ammo}
+      canvasRef={canvasRef}
+      handleClick={handleClick}
+      handleContext={handleContext}
+      getImg={getImg}
+      cursor={cursor}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- create a new mini game `pirates`
- provide a minimalist game engine, asset and audio loading
- implement title splash and in-game UI
- switch main page to load the new pirates game

## Testing
- `npx --no-install tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'react'...)*

------
https://chatgpt.com/codex/tasks/task_e_68801b499b4c832b8e234e541624df43