### PR TITLE
Fix cannonball audio reference

### DIFF
--- a/src/games/warbirds/utils.ts
+++ b/src/games/warbirds/utils.ts
@@ -429,7 +429,7 @@ export function spawnSystems(state: GameState): void {
           vx: CANNONBALL_SPEED,
           img: state.assets.getImg("cannonballImg") as HTMLImageElement,
         });
-        state.audio.play("cannon");
+        state.audio.play("cannonballSfx");
         state.burstRemaining--;
         state.burstCooldown = MACHINE_GUN_SHOT_INTERVAL;
       } else {


### PR DESCRIPTION
## Summary
- update cannonball audio key in `utils.ts`

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'next')*


------
https://chatgpt.com/codex/tasks/task_e_68801dc7d2bc832bba5ae546cb80a721