### PR TITLE
Add base path config for GitHub Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,6 +22,8 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
+        env:
+          NEXT_PUBLIC_BASE_PATH: "/lightgun-web"
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
 
+## Deploy on GitHub Pages
+
+To deploy the static build under a subpath like `https://USERNAME.github.io/lightgun-web/`,
+the build must know the repository name. The workflow sets the `NEXT_PUBLIC_BASE_PATH`
+environment variable and `next.config.ts` reads it to configure `basePath` and
+`assetPrefix`. When building locally you can replicate this with:
+
+```bash
+NEXT_PUBLIC_BASE_PATH=/lightgun-web npm run build
+```
+
 ## Project Overview
 
 This project is a TypeScript-based Next.js game. It uses React hooks and the Next.js app router to deliver a browser-based shooter under `src/games/warbirds`.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,14 @@
 import type { NextConfig } from "next";
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+
 const nextConfig: NextConfig = {
-  /* config options here */
   output: "export",
+  basePath,
+  assetPrefix: basePath,
+  images: {
+    unoptimized: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- configure `basePath` and `assetPrefix` for GitHub Pages
- set `NEXT_PUBLIC_BASE_PATH` when building in CI
- document how to build for GitHub Pages locally

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880a3ae0944832b85be2ab2171ec0a1