### PR TITLE
Improve audio fallback for unsupported types

### DIFF
--- a/src/hooks/useAudio.ts
+++ b/src/hooks/useAudio.ts
@@ -20,7 +20,13 @@ export const useAudio = (url: string, loop = false) => {
 
       // Check if browser supports this audio type
       if (a.canPlayType(mime) === "") {
-        console.warn(`Skipping audio load, unsupported type: ${mime}`);
+        if (ext.toLowerCase() !== "mp3" && !triedFallback) {
+          triedFallback = true;
+          const mp3Url = audioUrl.replace(/\.[^/.]+$/, ".mp3");
+          tryLoadAudio(mp3Url);
+        } else {
+          console.warn(`Skipping audio load, unsupported type: ${mime}`);
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary
- handle unsupported audio types before loading
- fall back to `.mp3` on `canPlayType` failure when possible

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688163d834f8832b96c12cadd5373842