### PR TITLE
Add audio util coverage for default options

### DIFF
--- a/src/utils/__tests__/audio.test.ts
+++ b/src/utils/__tests__/audio.test.ts
@@ -24,4 +24,22 @@ describe('audio utils', () => {
 
     expect(audioElement.pause).toHaveBeenCalled();
   });
+
+  test('rewindAndPlayAudio uses defaults when options omitted', () => {
+    const audioElement = document.createElement('audio');
+    audioElement.play = jest.fn();
+    const ref: RefObject<HTMLAudioElement> = { current: audioElement };
+
+    rewindAndPlayAudio(ref);
+
+    expect(audioElement.loop).toBe(false);
+    expect(audioElement.volume).toBe(1);
+    expect(audioElement.currentTime).toBe(0);
+    expect(audioElement.play).toHaveBeenCalled();
+  });
+
+  test('audio functions ignore undefined refs', () => {
+    expect(() => pauseAudio(undefined)).not.toThrow();
+    expect(() => rewindAndPlayAudio(undefined)).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- extend audio utility tests for default loop and volume
- verify audio helpers handle `undefined` refs gracefully

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688193d5c84c832bbc499fd4f4366497