### PR TITLE
Update Phase union

### DIFF
--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -64,9 +64,10 @@ export interface TextLabel {
 }
 
 /**
- * Main game phase/state for UI and logic.
+ * Main game phase/state for UI and logic. The initial asset loading phase has
+ * been removed, so the game starts in the "ready" state.
  */
-export type Phase = "loading" | "ready" | "go" | "playing" | "title";
+export type Phase = "ready" | "go" | "playing" | "title";
 
 /**
  * Alias for Phase, for rendering-specific state.


### PR DESCRIPTION
## Summary
- remove unused `"loading"` value from `Phase` union
- note that the game starts in `"ready"` phase

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881947d3e3c832b9ae21ac69c34de6c