### PR TITLE
Add laser beam fire SFX

### DIFF
--- a/src/games/warbirds/hooks/useGameAudio.ts
+++ b/src/games/warbirds/hooks/useGameAudio.ts
@@ -35,6 +35,7 @@ export function useGameAudio(): AudioMgr {
   const shieldSfx = useAudio("/audio/forceField_002.ogg");
   const shrinkSfx = useAudio("/audio/phaserDown1.ogg");
   const skullSfx = useAudio("/audio/lowDown.ogg");
+  const laserBeamFireSfx = useAudio("/audio/laserSmall_001.ogg");
   const shotSfx = useAudio("/audio/laser4.ogg");
   const thunderSfx = useAudio("/audio/thunderstrike.ogg");
   const thrusterSfx = useAudio("/audio/thrusterFire_000.ogg", true);
@@ -70,6 +71,7 @@ export function useGameAudio(): AudioMgr {
       shieldSfx,
       shrinkSfx,
       skullSfx,
+      laserBeamFireSfx,
       shotSfx,
       thunderSfx,
       thrusterSfx,
@@ -99,6 +101,7 @@ export function useGameAudio(): AudioMgr {
       shieldSfx,
       shrinkSfx,
       skullSfx,
+      laserBeamFireSfx,
       shotSfx,
       thunderSfx,
       thrusterSfx,

--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -1114,6 +1114,7 @@ export function useGameEngine() {
               frame: 0,
               frameCounter: 0,
             });
+            play("laserBeamFireSfx");
             state.current.laserBurstRemaining--;
             state.current.laserBurstCooldown = LASER_BEAM_SHOT_INTERVAL;
           } else {


### PR DESCRIPTION
## Summary
- add laser beam fire sound to audio hook
- play laser beam sound when powerup auto-fires

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881d5c75404832bb7ee4fd91fa98d8c