### PR TITLE
Add supershield powerup

### DIFF
--- a/src/constants/powerups.ts
+++ b/src/constants/powerups.ts
@@ -20,6 +20,7 @@ export const POWERUP_TYPES: PowerupType[] = [
   "napalm",
   "magnet",
   "shield",
+  "supershield",
   "shrink",
   "skull",
   "gunjam",
@@ -49,6 +50,7 @@ export const SUPER_POWERUP_TYPES: SuperPowerupType[] = [
   "supermag",
   "megaducks",
   "napalm",
+  "supershield",
   "laserbeam",
   "thunderstrike",
 ];

--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -1700,10 +1700,14 @@ export function useGameEngine() {
           !DEBUG_PLAYER_CRASH &&
           !state.current.isActive("ghost", state.current.frameCount)
         ) {
-          if (state.current.isActive("shield", state.current.frameCount)) {
-            // block it once:
-            // shield is one‐time use
-            state.current.activePowerups.shield.expires = 0;
+          if (
+            state.current.isActive("shield", state.current.frameCount) ||
+            state.current.isActive("supershield", state.current.frameCount)
+          ) {
+            // consume regular shield once
+            if (state.current.isActive("shield", state.current.frameCount)) {
+              state.current.activePowerups.shield.expires = 0;
+            }
             // trigger shield flash
             state.current.shieldFlash = 10;
             // shielded so no crash
@@ -2003,6 +2007,7 @@ export function useGameEngine() {
         // draw the shield “flash” only while our counter is active
         if (
           state.current.isActive("shield", state.current.frameCount) ||
+          state.current.isActive("supershield", state.current.frameCount) ||
           state.current.shieldFlash > 0
         ) {
           if (state.current.shieldFlash > 0) {
@@ -2509,9 +2514,14 @@ export function useGameEngine() {
           t.y >= state.current.y &&
           t.y <= state.current.y + PLANE_HEIGHT
         ) {
-          if (state.current.isActive("shield", state.current.frameCount)) {
-            // consume shield
-            state.current.activePowerups.shield.expires = 0;
+          if (
+            state.current.isActive("shield", state.current.frameCount) ||
+            state.current.isActive("supershield", state.current.frameCount)
+          ) {
+            // consume regular shield
+            if (state.current.isActive("shield", state.current.frameCount)) {
+              state.current.activePowerups.shield.expires = 0;
+            }
             state.current.shieldFlash = 10;
             play("shieldSfx");
           } else {

--- a/src/games/warbirds/utils.ts
+++ b/src/games/warbirds/utils.ts
@@ -39,6 +39,7 @@ export function initState(
     magnet: { expires: 0 },
     napalm: { expires: 0 },
     shield: { expires: 0 },
+    supershield: { expires: 0 },
     shrink: { expires: 0 },
     skull: { expires: 0 },
     spray: { expires: 0 },

--- a/src/types/objects.ts
+++ b/src/types/objects.ts
@@ -16,6 +16,7 @@ export type PowerupType =
   | "napalm"
   | "magnet"
   | "shield"
+  | "supershield"
   | "shrink"
   | "skull"
   | "gunjam"
@@ -41,6 +42,7 @@ export type SuperPowerupType =
   | "supermag"
   | "megaducks"
   | "napalm"
+  | "supershield"
   | "artillery"
   | "laserbeam"
   | "thunderstrike";


### PR DESCRIPTION
## Summary
- add `supershield` to PowerupType lists and super powerup lists
- initialize supershield timer in warbirds state
- show supershield bubble the same way as shield
- do not consume supershield on collisions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881df38f2a4832bb803adce10e1b7ee