### PR TITLE
Add turbulence anti-powerup

### DIFF
--- a/src/constants/powerups.ts
+++ b/src/constants/powerups.ts
@@ -31,6 +31,7 @@ export const POWERUP_TYPES: PowerupType[] = [
   "laserbeam",
   "thunderstrike",
   "windy",
+  "turbulence",
   "wings",
 ];
 
@@ -41,6 +42,7 @@ export const ANTI_POWERUP_TYPES: AntiPowerupType[] = [
   "sticky",
   "heavy",
   "windy",
+  "turbulence",
 ];
 
 /** High power, rare powerups that provide significant advantages */

--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -570,9 +570,20 @@ export function useGameEngine() {
             state.current.activePowerups.bomb.expires =
               state.current.frameCount + 1;
           } else if (ANTI_POWERUP_TYPES.includes(p.type as AntiPowerupType)) {
-            if (["sticky", "heavy", "windy"].includes(p.type)) {
+            if (["sticky", "heavy", "windy", "turbulence"].includes(p.type)) {
               // sticky and heavy powerups expire at POWERUP_DURATION
               state.current.activePowerups[p.type].expires = POWERUP_DURATION;
+              if (p.type === "turbulence") {
+                makeText(
+                  "Turbulence!",
+                  1,
+                  true,
+                  true,
+                  dims.width - 800,
+                  dims.height * 0.8,
+                  120
+                );
+              }
             } else {
               // other anti-powerups expire immediately
               state.current.activePowerups[p.type].expires =
@@ -1634,6 +1645,12 @@ export function useGameEngine() {
       if (!state.current.crashed) {
         state.current.vy += gravity;
         state.current.y += state.current.vy;
+
+        if (state.current.isActive("turbulence", state.current.frameCount)) {
+          state.current.vy += (Math.random() * 2 - 1) * 0.5;
+          state.current.y += (Math.random() * 2 - 1) * SCRAMBLE_INTENSITY;
+          state.current.planeAngle += (Math.random() * 2 - 1) * 0.2;
+        }
 
         // collision with ground
         if (state.current.y + PLANE_HEIGHT >= groundY) {

--- a/src/games/warbirds/utils.ts
+++ b/src/games/warbirds/utils.ts
@@ -48,6 +48,7 @@ export function initState(
     laserbeam: { expires: 0 },
     thunderstrike: { expires: 0 },
     windy: { expires: 0 },
+    turbulence: { expires: 0 },
     wings: { expires: 0 },
   };
 

--- a/src/types/objects.ts
+++ b/src/types/objects.ts
@@ -27,12 +27,19 @@ export type PowerupType =
   | "laserbeam"
   | "thunderstrike"
   | "windy"
+  | "turbulence"
   | "wings";
 
 /**
  * Types of anti-powerups (negative effects).
  */
-export type AntiPowerupType = "skull" | "gunjam" | "sticky" | "heavy" | "windy";
+export type AntiPowerupType =
+  | "skull"
+  | "gunjam"
+  | "sticky"
+  | "heavy"
+  | "windy"
+  | "turbulence";
 
 /**
  * Extra-strong, rare powerup types.


### PR DESCRIPTION
## Summary
- extend powerup lists with `turbulence`
- support turbulence powerup type in state and types
- display turbulence in the UI and add collection text
- implement turbulence effect that jitters the plane

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881e774304c832bbd66b9c9f38fe8c4