### PR TITLE
Add Straight Cash game skeleton

### DIFF
--- a/src/games/straightcash/components/GameUI.tsx
+++ b/src/games/straightcash/components/GameUI.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import Box from "@mui/material/Box";
+
+export interface GameUIProps {
+  cursor: string;
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
+  handleClick: (e: React.MouseEvent) => void;
+  handleContext: (e: React.MouseEvent) => void;
+}
+
+export default function GameUI({
+  cursor,
+  canvasRef,
+  handleClick,
+  handleContext,
+}: GameUIProps) {
+  return (
+    <Box position="relative" width="100vw" height="100dvh">
+      <canvas
+        ref={canvasRef}
+        onClick={handleClick}
+        onContextMenu={handleContext}
+        style={{
+          display: "block",
+          width: "100%",
+          height: "100%",
+          cursor,
+        }}
+      />
+    </Box>
+  );
+}

--- a/src/games/straightcash/components/ReadyGoSplash.tsx
+++ b/src/games/straightcash/components/ReadyGoSplash.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import Box from "@mui/material/Box";
+import {
+  SCORE_DIGIT_PATH,
+  SCORE_DIGIT_WIDTH,
+  SCORE_DIGIT_HEIGHT,
+} from "@/constants/ui";
+import { SKY_COLOR } from "../constants";
+import { withBasePath } from "@/utils/basePath";
+
+export interface ReadyGoSplashProps {
+  phase: "ready" | "go";
+  countdown: number | null;
+}
+
+export const ReadyGoSplash: React.FC<ReadyGoSplashProps> = ({ phase, countdown }) => {
+  const src = withBasePath(
+    phase === "ready"
+      ? "/assets/shooting-gallery/PNG/HUD/text_ready.png"
+      : "/assets/shooting-gallery/PNG/HUD/text_go.png"
+  );
+
+  return (
+    <Box
+      position="relative"
+      width="100vw"
+      height="100dvh"
+      sx={{ backgroundColor: SKY_COLOR }}
+      display="flex"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <Box
+        component="img"
+        src={src}
+        alt={phase}
+        sx={{ width: 300, height: "auto" }}
+      />
+      {phase === "ready" && countdown != null && (
+        <Box
+          component="img"
+          src={withBasePath(`${SCORE_DIGIT_PATH}${countdown}.png`)}
+          alt={`${countdown}`}
+          sx={{
+            mt: 2,
+            width: SCORE_DIGIT_WIDTH * 5,
+            height: SCORE_DIGIT_HEIGHT * 5,
+            animation: "fadeUp 1s ease-out forwards",
+          }}
+        />
+      )}
+    </Box>
+  );
+};
+
+export default ReadyGoSplash;

--- a/src/games/straightcash/components/TitleSplash.tsx
+++ b/src/games/straightcash/components/TitleSplash.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import Box from "@mui/material/Box";
+
+export interface TitleSplashProps {
+  onStart: () => void;
+  titleSrc: string;
+  backgroundColor: string;
+  cursor: string;
+}
+
+export const TitleSplash: React.FC<TitleSplashProps> = ({
+  onStart,
+  titleSrc,
+  backgroundColor,
+  cursor,
+}) => (
+  <Box
+    position="relative"
+    width="100vw"
+    height="100dvh"
+    sx={{ backgroundColor, cursor: "pointer" }}
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    onClick={onStart}
+  >
+    <Box
+      component="img"
+      src={titleSrc}
+      alt="Straight Cash"
+      sx={{ width: "auto", height: "100%", cursor }}
+    />
+  </Box>
+);
+
+export default TitleSplash;

--- a/src/games/straightcash/constants.ts
+++ b/src/games/straightcash/constants.ts
@@ -1,0 +1,4 @@
+import { BASE_PATH } from "@/utils/basePath";
+
+export const SKY_COLOR = "#6CA6CD";
+export const DEFAULT_CURSOR = `url('${BASE_PATH}/assets/shooting-gallery/PNG/HUD/crosshair_red_small.png') 16 16, auto`;

--- a/src/games/straightcash/hooks/useGameEngine.ts
+++ b/src/games/straightcash/hooks/useGameEngine.ts
@@ -1,0 +1,42 @@
+import { useState, useRef, useCallback } from "react";
+import { DEFAULT_CURSOR } from "../constants";
+
+export default function useGameEngine() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [phase, setPhase] = useState<"title" | "ready" | "go" | "playing">(
+    "title"
+  );
+  const [countdown] = useState<number | null>(null);
+
+  const ui = { cursor: DEFAULT_CURSOR };
+
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    // placeholder for gameplay interaction
+  }, []);
+
+  const handleContext = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+  }, []);
+
+  const resetGame = useCallback(() => {
+    setPhase("title");
+  }, []);
+
+  const getImg = useCallback(() => undefined, []);
+
+  const startSplash = useCallback(() => {
+    setPhase("playing");
+  }, []);
+
+  return {
+    phase,
+    countdown,
+    ui,
+    canvasRef,
+    handleClick,
+    handleContext,
+    resetGame,
+    getImg,
+    startSplash,
+  };
+}

--- a/src/games/straightcash/index.tsx
+++ b/src/games/straightcash/index.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import React from "react";
+import { DEFAULT_CURSOR, SKY_COLOR } from "./constants";
+import { withBasePath } from "@/utils/basePath";
+import TitleSplash from "./components/TitleSplash";
+import GameUI from "./components/GameUI";
+import ReadyGoSplash from "./components/ReadyGoSplash";
+import useGameEngine from "./hooks/useGameEngine";
+
+export default function Game() {
+  const {
+    phase,
+    countdown,
+    ui,
+    canvasRef,
+    handleClick,
+    handleContext,
+    resetGame,
+    getImg,
+    startSplash,
+  } = useGameEngine();
+
+  if (phase === "title") {
+    return (
+      <TitleSplash
+        onStart={startSplash}
+        titleSrc={withBasePath("/assets/titles/warbirds_title.png")}
+        backgroundColor={SKY_COLOR}
+        cursor={DEFAULT_CURSOR}
+      />
+    );
+  }
+
+  if (phase === "ready" || phase === "go") {
+    return <ReadyGoSplash phase={phase} countdown={countdown} />;
+  }
+
+  return (
+    <GameUI
+      cursor={ui.cursor}
+      canvasRef={canvasRef}
+      handleClick={handleClick}
+      handleContext={handleContext}
+    />
+  );
+}
+
+export { Game };


### PR DESCRIPTION
## Summary
- scaffold a new game `straightcash`
- implement basic `Game` component with splash screens
- add placeholder hooks and UI components

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881f36c36d4832b9aeee08c7ff9acfa