### PR TITLE
Add bonus wheel feature

### DIFF
--- a/src/games/straightcash/components/BonusWheel.tsx
+++ b/src/games/straightcash/components/BonusWheel.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useRef, useState } from "react";
+import Box from "@mui/material/Box";
+
+export interface BonusWheelProps {
+  spinning: boolean;
+  onFinish: (reward: string) => void;
+}
+
+const REWARDS = [
+  "20",
+  "25",
+  "30",
+  "50",
+  "100",
+  "250",
+  "500",
+  "Minor",
+  "Major",
+  "Grand",
+];
+
+const COLORS = [
+  "#f44336",
+  "#e91e63",
+  "#9c27b0",
+  "#673ab7",
+  "#3f51b5",
+  "#2196f3",
+  "#009688",
+  "#4caf50",
+  "#ff9800",
+  "#795548",
+];
+
+export default function BonusWheel({ spinning, onFinish }: BonusWheelProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [rotation, setRotation] = useState(0);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const radius = canvas.width / 2;
+    const wedgeAngle = (2 * Math.PI) / REWARDS.length;
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    for (let i = 0; i < REWARDS.length; i++) {
+      ctx.beginPath();
+      ctx.moveTo(radius, radius);
+      ctx.arc(
+        radius,
+        radius,
+        radius,
+        i * wedgeAngle - Math.PI / 2,
+        (i + 1) * wedgeAngle - Math.PI / 2
+      );
+      ctx.closePath();
+      ctx.fillStyle = COLORS[i % COLORS.length];
+      ctx.fill();
+      ctx.save();
+      ctx.translate(radius, radius);
+      ctx.rotate(i * wedgeAngle + wedgeAngle / 2 - Math.PI / 2);
+      ctx.textAlign = "center";
+      ctx.fillStyle = "#fff";
+      ctx.font = "16px sans-serif";
+      ctx.fillText(REWARDS[i], radius * 0.6, 5);
+      ctx.restore();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!spinning) return;
+    const wedgeSize = 360 / REWARDS.length;
+    const spins = Math.floor(Math.random() * 3) + 3; // 3-5 full spins
+    const target = Math.floor(Math.random() * REWARDS.length);
+    const finalAngle = spins * 360 + target * wedgeSize + wedgeSize / 2;
+    const duration = 4000;
+    setRotation(finalAngle);
+    const nudge = Math.random() * 10 - 5;
+    const id = setTimeout(() => {
+      setRotation((r) => r + nudge);
+      setTimeout(() => onFinish(REWARDS[target]), 500);
+    }, duration);
+    return () => clearTimeout(id);
+  }, [spinning, onFinish]);
+
+  return (
+    <Box
+      position="relative"
+      width={300}
+      height={300}
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Box
+        component="canvas"
+        ref={canvasRef}
+        width={300}
+        height={300}
+        sx={{ transform: `rotate(${rotation}deg)`, transition: spinning ? "transform 4s ease-out" : undefined }}
+      />
+      <Box
+        position="absolute"
+        top={0}
+        left="50%"
+        sx={{ width: 0, height: 0, borderLeft: "10px solid transparent", borderRight: "10px solid transparent", borderBottom: "20px solid #000", transform: "translateX(-50%)" }}
+      />
+    </Box>
+  );
+}

--- a/src/games/straightcash/components/GameUI.tsx
+++ b/src/games/straightcash/components/GameUI.tsx
@@ -4,6 +4,7 @@ import Button from "@mui/material/Button";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Reel from "./Reel";
+import BonusWheel from "./BonusWheel";
 
 export interface GameUIProps {
   cursor: string;
@@ -14,6 +15,9 @@ export interface GameUIProps {
   spinning: boolean[];
   locked: boolean[];
   stopReel: (index: number) => void;
+  onSpinEnd: (index: number, isWheel: boolean) => void;
+  wheelSpinning: boolean;
+  onWheelFinish: (reward: string) => void;
 }
 
 export default function GameUI({
@@ -25,6 +29,9 @@ export default function GameUI({
   spinning,
   locked,
   stopReel,
+  onSpinEnd,
+  wheelSpinning,
+  onWheelFinish,
 }: GameUIProps) {
   const [tokenValue, setTokenValue] = useState<number>(1);
 
@@ -36,9 +43,16 @@ export default function GameUI({
 
   return (
     <Box position="relative" width="100vw" height="100dvh" display="flex" flexDirection="column" alignItems="center" justifyContent="center">
+      <BonusWheel spinning={wheelSpinning} onFinish={onWheelFinish} />
       <Box display="flex" gap={2} mb={2}>
         {spinning.map((spin, i) => (
-          <Reel key={i} spinning={spin} locked={locked[i]} onStop={() => stopReel(i)} />
+          <Reel
+            key={i}
+            spinning={spin}
+            locked={locked[i]}
+            onStop={() => stopReel(i)}
+            onSpinEnd={(isWheel) => onSpinEnd(i, isWheel)}
+          />
         ))}
       </Box>
       <Box mb={2}>

--- a/src/games/straightcash/components/Reel.tsx
+++ b/src/games/straightcash/components/Reel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState, useRef } from "react";
 import Box from "@mui/material/Box";
 import useStraightCashAssets from "../hooks/useStraightCashAssets";
 
@@ -6,11 +6,17 @@ export interface ReelProps {
   spinning: boolean;
   locked: boolean;
   onStop: () => void;
+  onSpinEnd?: (isWheel: boolean) => void;
 }
 
 const ITEM_SIZE = 120;
 
-export const Reel: React.FC<ReelProps> = ({ spinning, locked, onStop }) => {
+export const Reel: React.FC<ReelProps> = ({
+  spinning,
+  locked,
+  onStop,
+  onSpinEnd,
+}) => {
   const { assetRefs, ready } = useStraightCashAssets();
 
   const items = useMemo(() => {
@@ -45,6 +51,7 @@ export const Reel: React.FC<ReelProps> = ({ spinning, locked, onStop }) => {
   }, [ready, assetRefs]);
 
   const [index, setIndex] = useState(0);
+  const prevSpinning = useRef(spinning);
 
   useEffect(() => {
     if (!spinning || items.length === 0) return;
@@ -53,6 +60,14 @@ export const Reel: React.FC<ReelProps> = ({ spinning, locked, onStop }) => {
     }, 100);
     return () => clearInterval(id);
   }, [spinning, items.length]);
+
+  useEffect(() => {
+    if (prevSpinning.current && !spinning && onSpinEnd) {
+      const wheelIndex = items.length - 1;
+      onSpinEnd(index === wheelIndex);
+    }
+    prevSpinning.current = spinning;
+  }, [spinning, index, onSpinEnd, items.length]);
 
   const handleClick = () => {
     if (!locked) {

--- a/src/games/straightcash/hooks/useStraightCashGameEngine.ts
+++ b/src/games/straightcash/hooks/useStraightCashGameEngine.ts
@@ -27,6 +27,8 @@ export default function useStraightCashGameEngine() {
   ]);
   const [bet, setBet] = useState<number>(1);
   const [tokens, setTokens] = useState<number>(100);
+  const [reelResults, setReelResults] = useState<boolean[]>([false, false, false]);
+  const [wheelSpinning, setWheelSpinning] = useState(false);
 
   const autoStopRefs = useRef<(ReturnType<typeof setTimeout> | null)[]>([
     null,
@@ -72,6 +74,17 @@ export default function useStraightCashGameEngine() {
       autoStopRefs.current[index] = null;
     }
   }, []);
+
+  const handleSpinEnd = useCallback(
+    (index: number, isWheel: boolean) => {
+      setReelResults((prev) => {
+        const arr = [...prev];
+        arr[index] = isWheel;
+        return arr;
+      });
+    },
+    []
+  );
 
   const handleReelClick = useCallback(
     (index: number, e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -125,6 +138,13 @@ export default function useStraightCashGameEngine() {
     }
   }, [spinning]);
 
+  useEffect(() => {
+    if (spinning.every((s) => !s) && reelResults.every((r) => r)) {
+      setPhase("wheel");
+      setWheelSpinning(true);
+    }
+  }, [spinning, reelResults]);
+
   const resetGame = useCallback(() => {
     setPhase("title");
     setReelPos([0, 0, 0]);
@@ -147,6 +167,13 @@ export default function useStraightCashGameEngine() {
     setPhase("playing");
   }, []);
 
+  const handleWheelFinish = useCallback((reward: string) => {
+    setWheelSpinning(false);
+    setPhase("playing");
+    setReelResults([false, false, false]);
+    // placeholder: reward handling could modify tokens
+  }, []);
+
   return {
     phase,
     countdown,
@@ -159,12 +186,15 @@ export default function useStraightCashGameEngine() {
     startSplash,
     startSpins,
     stopReel,
+    handleSpinEnd,
     handleReelClick,
     reelPos,
     reelClicks,
     spinSpeed,
     spinning,
     locked,
+    wheelSpinning,
+    handleWheelFinish,
     bet,
     tokens,
     setReelPos,

--- a/src/games/straightcash/index.tsx
+++ b/src/games/straightcash/index.tsx
@@ -23,6 +23,9 @@ export default function Game() {
     spinning,
     locked,
     stopReel,
+    handleSpinEnd,
+    wheelSpinning,
+    handleWheelFinish,
   } = useStraightCashGameEngine();
 
   if (phase === "title") {
@@ -50,6 +53,9 @@ export default function Game() {
       spinning={spinning}
       locked={locked}
       stopReel={stopReel}
+      onSpinEnd={handleSpinEnd}
+      wheelSpinning={wheelSpinning}
+      onWheelFinish={handleWheelFinish}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add bonus wheel canvas with reward wedges
- update reels to report when spinning stops
- trigger wheel spin when all reels land on the wheel chip
- display wheel above reels in the game UI

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881fc503c34832ba6b5c8619b8b98fb