### PR TITLE
Add jackpot display with dynamic values

### DIFF
--- a/src/games/straightcash/components/GameUI.tsx
+++ b/src/games/straightcash/components/GameUI.tsx
@@ -5,6 +5,7 @@ import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Reel from "./Reel";
 import BonusWheel from "./BonusWheel";
+import JackpotDisplay from "./JackpotDisplay";
 
 export interface GameUIProps {
   cursor: string;
@@ -18,6 +19,7 @@ export interface GameUIProps {
   onSpinEnd: (index: number, isWheel: boolean) => void;
   wheelSpinning: boolean;
   onWheelFinish: (reward: string) => void;
+  bet: number;
 }
 
 export default function GameUI({
@@ -32,6 +34,7 @@ export default function GameUI({
   onSpinEnd,
   wheelSpinning,
   onWheelFinish,
+  bet,
 }: GameUIProps) {
   const [tokenValue, setTokenValue] = useState<number>(1);
 
@@ -43,6 +46,7 @@ export default function GameUI({
 
   return (
     <Box position="relative" width="100vw" height="100dvh" display="flex" flexDirection="column" alignItems="center" justifyContent="center">
+      <JackpotDisplay bet={bet} />
       <BonusWheel spinning={wheelSpinning} onFinish={onWheelFinish} />
       <Box display="flex" gap={2} mb={2}>
         {spinning.map((spin, i) => (

--- a/src/games/straightcash/components/JackpotDisplay.tsx
+++ b/src/games/straightcash/components/JackpotDisplay.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+
+export interface JackpotDisplayProps {
+  bet: number;
+}
+
+interface JackpotValues {
+  minor: number;
+  major: number;
+  grand: number;
+}
+
+function randomInRange(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+export default function JackpotDisplay({ bet }: JackpotDisplayProps) {
+  const [values, setValues] = useState<JackpotValues>(() => ({
+    minor: randomInRange(bet * 50, bet * 100),
+    major: randomInRange(bet * 100, bet * 200),
+    grand: randomInRange(bet * 200, bet * 400),
+  }));
+
+  useEffect(() => {
+    setValues({
+      minor: randomInRange(bet * 50, bet * 100),
+      major: randomInRange(bet * 100, bet * 200),
+      grand: randomInRange(bet * 200, bet * 400),
+    });
+  }, [bet]);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setValues((v) => ({
+        minor: v.minor + randomInRange(1, 3),
+        major: v.major + randomInRange(2, 5),
+        grand: v.grand + randomInRange(5, 10),
+      }));
+    }, 3000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <Box display="flex" gap={2} mb={1}>
+      <Typography color="gold">Minor: {values.minor}</Typography>
+      <Typography color="goldenrod">Major: {values.major}</Typography>
+      <Typography color="orange">Grand: {values.grand}</Typography>
+    </Box>
+  );
+}

--- a/src/games/straightcash/index.tsx
+++ b/src/games/straightcash/index.tsx
@@ -26,6 +26,7 @@ export default function Game() {
     handleSpinEnd,
     wheelSpinning,
     handleWheelFinish,
+    bet,
   } = useStraightCashGameEngine();
 
   if (phase === "title") {
@@ -56,6 +57,7 @@ export default function Game() {
       onSpinEnd={handleSpinEnd}
       wheelSpinning={wheelSpinning}
       onWheelFinish={handleWheelFinish}
+      bet={bet}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add `JackpotDisplay` component to show Minor/Major/Grand jackpots
- periodically increment jackpot values
- display jackpot totals above the bonus wheel
- plumb bet amount through `GameUI`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881fdd58960832bb37f647511c1afbb