### PR TITLE
Implement basic payout logic for Straight Cash

### DIFF
--- a/src/games/straightcash/components/GameUI.tsx
+++ b/src/games/straightcash/components/GameUI.tsx
@@ -12,11 +12,11 @@ export interface GameUIProps {
   canvasRef: React.RefObject<HTMLCanvasElement | null>;
   handleClick: (e: React.MouseEvent) => void;
   handleContext: (e: React.MouseEvent) => void;
-  startSpins: (amount: number) => void;
+  startSpins: (amount: number, denom: number) => void;
   spinning: boolean[];
   locked: boolean[];
-  stopReel: (index: number) => void;
-  onSpinEnd: (index: number, isWheel: boolean) => void;
+  handleReelClick: (index: number, e: React.MouseEvent<HTMLDivElement>) => void;
+  onSpinEnd: (index: number, result: string) => void;
   wheelSpinning: boolean;
   onWheelFinish: (reward: string) => void;
   bet: number;
@@ -30,7 +30,7 @@ export default function GameUI({
   startSpins,
   spinning,
   locked,
-  stopReel,
+  handleReelClick,
   onSpinEnd,
   wheelSpinning,
   onWheelFinish,
@@ -39,7 +39,7 @@ export default function GameUI({
   const [tokenValue, setTokenValue] = useState<number>(1);
 
   const handleBet = (amount: number) => {
-    startSpins(amount);
+    startSpins(amount, tokenValue);
   };
 
   const tokenOptions = [0.25, 1, 5, 10, 50];
@@ -54,8 +54,8 @@ export default function GameUI({
             key={i}
             spinning={spin}
             locked={locked[i]}
-            onStop={() => stopReel(i)}
-            onSpinEnd={(isWheel) => onSpinEnd(i, isWheel)}
+            onStop={(e) => handleReelClick(i, e)}
+            onSpinEnd={(result) => onSpinEnd(i, result)}
           />
         ))}
       </Box>

--- a/src/games/straightcash/index.tsx
+++ b/src/games/straightcash/index.tsx
@@ -22,7 +22,7 @@ export default function Game() {
     startSpins,
     spinning,
     locked,
-    stopReel,
+    handleReelClick,
     handleSpinEnd,
     wheelSpinning,
     handleWheelFinish,
@@ -53,7 +53,7 @@ export default function Game() {
       startSpins={startSpins}
       spinning={spinning}
       locked={locked}
-      stopReel={stopReel}
+      handleReelClick={handleReelClick}
       onSpinEnd={handleSpinEnd}
       wheelSpinning={wheelSpinning}
       onWheelFinish={handleWheelFinish}


### PR DESCRIPTION
## Summary
- calculate card values and overlay indicators when reels stop
- adjust payouts for token denomination and cap at 10,500
- thread reel click events through GameUI

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881fefa6cb8832b8a470924ebbf0a08