### PR TITLE
Implement dice overlay for +spin reels

### DIFF
--- a/src/games/straightcash/components/GameUI.tsx
+++ b/src/games/straightcash/components/GameUI.tsx
@@ -15,6 +15,7 @@ export interface GameUIProps {
   startSpins: (amount: number, denom: number) => void;
   spinning: boolean[];
   locked: boolean[];
+  showDie: boolean[];
   handleReelClick: (index: number, e: React.MouseEvent<HTMLDivElement>) => void;
   onSpinEnd: (index: number, result: string) => void;
   wheelSpinning: boolean;
@@ -30,6 +31,7 @@ export default function GameUI({
   startSpins,
   spinning,
   locked,
+  showDie,
   handleReelClick,
   onSpinEnd,
   wheelSpinning,
@@ -54,6 +56,7 @@ export default function GameUI({
             key={i}
             spinning={spin}
             locked={locked[i]}
+            showDie={showDie[i]}
             onStop={(e) => handleReelClick(i, e)}
             onSpinEnd={(result) => onSpinEnd(i, result)}
           />

--- a/src/games/straightcash/hooks/useStraightCashAssets.ts
+++ b/src/games/straightcash/hooks/useStraightCashAssets.ts
@@ -73,6 +73,11 @@ export function useStraightCashAssets(): {
       }
     }
 
+    // ─── PLUS IMAGE ─────────────────────────────────────────────────
+    assetRefs.current.plusImg = loadImg(
+      "/assets/shooting-gallery/PNG/HUD/text_plus_small.png"
+    );
+
     // ─── WHEEL BONUS CHIP ────────────────────────────────────────────
     assetRefs.current.wheelBonusChipImg = loadImg(
       "/assets/boardgame/PNG/Chips/chipGreenWhite_border.png"

--- a/src/games/straightcash/index.tsx
+++ b/src/games/straightcash/index.tsx
@@ -22,6 +22,7 @@ export default function Game() {
     startSpins,
     spinning,
     locked,
+    dieActive,
     handleReelClick,
     handleSpinEnd,
     wheelSpinning,
@@ -53,6 +54,7 @@ export default function Game() {
       startSpins={startSpins}
       spinning={spinning}
       locked={locked}
+      showDie={dieActive}
       handleReelClick={handleReelClick}
       onSpinEnd={handleSpinEnd}
       wheelSpinning={wheelSpinning}


### PR DESCRIPTION
## Summary
- load plus spin image for Straight Cash assets
- track die overlay state in the slot machine game engine
- spin reel again when the die is clicked
- display rotating die overlay on locked reels

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688200f59058832baf004fa465d5e723