### PR TITLE
Add bonus wheel spin trigger

### DIFF
--- a/public/assets/shooting-gallery/PNG/HUD/text_spin.svg
+++ b/public/assets/shooting-gallery/PNG/HUD/text_spin.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 80">
+  <rect width="200" height="80" rx="10" ry="10" fill="red" />
+  <text x="100" y="55" font-family="Arial, Helvetica, sans-serif" font-size="48" fill="white" text-anchor="middle" dominant-baseline="middle">SPIN</text>
+</svg>

--- a/src/games/straightcash/components/GameUI.tsx
+++ b/src/games/straightcash/components/GameUI.tsx
@@ -6,6 +6,7 @@ import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Reel from "./Reel";
 import BonusWheel from "./BonusWheel";
 import JackpotDisplay from "./JackpotDisplay";
+import { withBasePath } from "@/utils/basePath";
 
 export interface GameUIProps {
   cursor: string;
@@ -20,6 +21,8 @@ export interface GameUIProps {
   onSpinEnd: (index: number, result: string) => void;
   wheelSpinning: boolean;
   onWheelFinish: (reward: string) => void;
+  wheelReady: boolean;
+  onWheelStart: () => void;
   bet: number;
 }
 
@@ -36,6 +39,8 @@ export default function GameUI({
   onSpinEnd,
   wheelSpinning,
   onWheelFinish,
+  wheelReady,
+  onWheelStart,
   bet,
 }: GameUIProps) {
   const [tokenValue, setTokenValue] = useState<number>(1);
@@ -55,7 +60,26 @@ export default function GameUI({
   return (
     <Box position="relative" width="100vw" height="100dvh" display="flex" flexDirection="column" alignItems="center" justifyContent="center">
       <JackpotDisplay bet={bet} />
-      <BonusWheel spinning={wheelSpinning} onFinish={onWheelFinish} />
+      <Box position="relative">
+        <BonusWheel spinning={wheelSpinning} onFinish={onWheelFinish} />
+        {wheelReady && !wheelSpinning && (
+          <Box
+            component="img"
+            src={withBasePath("/assets/shooting-gallery/PNG/HUD/text_spin.svg")}
+            alt="Spin"
+            onClick={onWheelStart}
+            sx={{
+              position: "absolute",
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+              width: 150,
+              height: "auto",
+              cursor: "pointer",
+            }}
+          />
+        )}
+      </Box>
       <Box display="flex" gap={2} mb={2}>
         {spinning.map((spin, i) => (
           <Reel

--- a/src/games/straightcash/hooks/useStraightCashGameEngine.ts
+++ b/src/games/straightcash/hooks/useStraightCashGameEngine.ts
@@ -32,6 +32,7 @@ export default function useStraightCashGameEngine() {
   const [reelValues, setReelValues] = useState<number[]>([0, 0, 0]);
   const [tokenValue, setTokenValue] = useState<number>(1);
   const [wheelSpinning, setWheelSpinning] = useState(false);
+  const [wheelReady, setWheelReady] = useState(false);
 
   const isReelDisabled = useCallback(
     (index: number) => {
@@ -211,8 +212,7 @@ export default function useStraightCashGameEngine() {
     if (spinning.every((s) => !s)) {
       const activeIndices = [0, 1, 2].filter((i) => !isReelDisabled(i));
       if (activeIndices.every((i) => reelResults[i])) {
-        setPhase("wheel");
-        setWheelSpinning(true);
+        setWheelReady(true);
       } else {
         const totalValue = reelValues.reduce(
           (sum, val, i) => (isReelDisabled(i) ? sum : sum + val),
@@ -247,6 +247,7 @@ export default function useStraightCashGameEngine() {
     autoStopRefs.current = [null, null, null];
     setBet(1);
     setTokens(100);
+    setWheelReady(false);
     textLabels.current = [];
   }, []);
 
@@ -255,6 +256,14 @@ export default function useStraightCashGameEngine() {
   const startSplash = useCallback(() => {
     setPhase("playing");
   }, []);
+
+  const handleWheelStart = useCallback(() => {
+    if (!wheelReady) return;
+    setWheelReady(false);
+    setWheelSpinning(true);
+    setPhase("wheel");
+    audioMgr.play("chipLay1Sfx");
+  }, [wheelReady, audioMgr]);
 
   const handleWheelFinish = useCallback((reward: string) => {
     setWheelSpinning(false);
@@ -283,7 +292,9 @@ export default function useStraightCashGameEngine() {
     spinning,
     locked,
     dieActive,
+    wheelReady,
     wheelSpinning,
+    handleWheelStart,
     handleWheelFinish,
     bet,
     tokens,

--- a/src/games/straightcash/index.tsx
+++ b/src/games/straightcash/index.tsx
@@ -26,6 +26,8 @@ export default function Game() {
     handleReelClick,
     handleSpinEnd,
     wheelSpinning,
+    wheelReady,
+    handleWheelStart,
     handleWheelFinish,
     bet,
   } = useStraightCashGameEngine();
@@ -58,6 +60,8 @@ export default function Game() {
       handleReelClick={handleReelClick}
       onSpinEnd={handleSpinEnd}
       wheelSpinning={wheelSpinning}
+      wheelReady={wheelReady}
+      onWheelStart={handleWheelStart}
       onWheelFinish={handleWheelFinish}
       bet={bet}
     />


### PR DESCRIPTION
## Summary
- add inline spin graphic
- wait for player click before starting the bonus wheel
- expose wheel start callback via game engine
- overlay spin button in GameUI

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6882044ddd98832b8a636f0ebfebff59