### PR TITLE
Use crosshair cursor everywhere

### DIFF
--- a/src/games/straightcash/components/GameUI.tsx
+++ b/src/games/straightcash/components/GameUI.tsx
@@ -10,6 +10,7 @@ import { withBasePath } from "@/utils/basePath";
 
 export interface GameUIProps {
   cursor: string;
+  onShot: () => void;
   canvasRef: React.RefObject<HTMLCanvasElement | null>;
   handleClick: (e: React.MouseEvent) => void;
   handleContext: (e: React.MouseEvent) => void;
@@ -28,6 +29,7 @@ export interface GameUIProps {
 
 export default function GameUI({
   cursor,
+  onShot,
   canvasRef,
   handleClick,
   handleContext,
@@ -58,7 +60,16 @@ export default function GameUI({
   };
 
   return (
-    <Box position="relative" width="100vw" height="100dvh" display="flex" flexDirection="column" alignItems="center" justifyContent="center">
+    <Box
+      position="relative"
+      width="100vw"
+      height="100dvh"
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      onClickCapture={onShot}
+    >
       <JackpotDisplay bet={bet} />
       <Box position="relative">
         <BonusWheel spinning={wheelSpinning} onFinish={onWheelFinish} />
@@ -75,7 +86,7 @@ export default function GameUI({
               transform: "translate(-50%, -50%)",
               width: 150,
               height: "auto",
-              cursor: "pointer",
+              cursor,
             }}
           />
         )}
@@ -90,6 +101,7 @@ export default function GameUI({
             showDie={showDie[i]}
             onStop={(e) => handleReelClick(i, e)}
             onSpinEnd={(result) => onSpinEnd(i, result)}
+            cursor={cursor}
           />
         ))}
       </Box>
@@ -103,7 +115,7 @@ export default function GameUI({
           size="small"
         >
           {tokenOptions.map((val) => (
-            <ToggleButton key={val} value={val}>
+            <ToggleButton key={val} value={val} sx={{ cursor }}>
               {val === 0.25 ? "25¢" : `$${val}`}
             </ToggleButton>
           ))}
@@ -111,7 +123,12 @@ export default function GameUI({
       </Box>
       <Box display="flex" gap={1}>
         {[1, 5, 10].map((n) => (
-          <Button key={n} variant="contained" onClick={() => handleBet(n)}>
+          <Button
+            key={n}
+            variant="contained"
+            onClick={() => handleBet(n)}
+            sx={{ cursor }}
+          >
             {n} Token{n > 1 ? "s" : ""}
           </Button>
         ))}

--- a/src/games/straightcash/components/Reel.tsx
+++ b/src/games/straightcash/components/Reel.tsx
@@ -13,6 +13,7 @@ export interface ReelProps {
   showDie?: boolean;
   onStop: (e: React.MouseEvent<HTMLDivElement>) => void;
   onSpinEnd?: (result: string) => void;
+  cursor: string;
 }
 
 const ITEM_SIZE = 120;
@@ -24,6 +25,7 @@ export const Reel: React.FC<ReelProps> = ({
   showDie,
   onStop,
   onSpinEnd,
+  cursor,
 }) => {
   const { assetRefs, ready } = useStraightCashAssets();
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -118,7 +120,7 @@ export const Reel: React.FC<ReelProps> = ({
       position="relative"
       onClick={handleClick}
       sx={{
-        cursor: locked || disabled ? "default" : "pointer",
+        cursor: locked || disabled ? "default" : cursor,
         pointerEvents: disabled ? "none" : "auto",
       }}
     >

--- a/src/games/straightcash/components/TitleSplash.tsx
+++ b/src/games/straightcash/components/TitleSplash.tsx
@@ -6,6 +6,7 @@ export interface TitleSplashProps {
   titleSrc: string;
   backgroundColor: string;
   cursor: string;
+  onShot: () => void;
 }
 
 export const TitleSplash: React.FC<TitleSplashProps> = ({
@@ -13,16 +14,20 @@ export const TitleSplash: React.FC<TitleSplashProps> = ({
   titleSrc,
   backgroundColor,
   cursor,
+  onShot,
 }) => (
   <Box
     position="relative"
     width="100vw"
     height="100dvh"
-    sx={{ backgroundColor, cursor: "pointer" }}
+    sx={{ backgroundColor, cursor }}
     display="flex"
     justifyContent="center"
     alignItems="center"
-    onClick={onStart}
+    onClick={() => {
+      onShot();
+      onStart();
+    }}
   >
     <Box
       component="img"

--- a/src/games/straightcash/constants.ts
+++ b/src/games/straightcash/constants.ts
@@ -2,3 +2,4 @@ import { BASE_PATH } from "@/utils/basePath";
 
 export const SKY_COLOR = "#6CA6CD";
 export const DEFAULT_CURSOR = `url('${BASE_PATH}/assets/shooting-gallery/PNG/HUD/crosshair_red_small.png') 16 16, auto`;
+export const SHOT_CURSOR = `url('${BASE_PATH}/assets/shooting-gallery/PNG/Objects/shot_brown_large.png') 16 16, auto`;

--- a/src/games/straightcash/hooks/useStraightCashGameEngine.ts
+++ b/src/games/straightcash/hooks/useStraightCashGameEngine.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
-import { DEFAULT_CURSOR } from "../constants";
+import { DEFAULT_CURSOR, SHOT_CURSOR } from "../constants";
 import { AudioMgr } from "@/types/audio";
 import { TextLabel } from "@/types/ui";
 import useStraightCashAudio from "./useStraightCashAudio";
@@ -70,7 +70,13 @@ export default function useStraightCashGameEngine() {
   const slideIdxRef = useRef(0);
   const slideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const ui = { cursor: DEFAULT_CURSOR };
+  const [cursor, setCursor] = useState<string>(DEFAULT_CURSOR);
+  const triggerShotCursor = useCallback(() => {
+    setCursor(SHOT_CURSOR);
+    setTimeout(() => setCursor(DEFAULT_CURSOR), 100);
+  }, []);
+
+  const ui = { cursor };
 
   const makeText = useCallback(
     (text: string, scale: number, x?: number, y?: number, maxAge = 60) => {
@@ -350,5 +356,6 @@ export default function useStraightCashGameEngine() {
     makeText,
     textLabels: textLabels.current,
     audioMgr,
+    triggerShotCursor,
   };
 }

--- a/src/games/straightcash/index.tsx
+++ b/src/games/straightcash/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { DEFAULT_CURSOR, SKY_COLOR } from "./constants";
+import { SKY_COLOR } from "./constants";
 import { withBasePath } from "@/utils/basePath";
 import TitleSplash from "./components/TitleSplash";
 import GameUI from "./components/GameUI";
@@ -30,6 +30,7 @@ export default function Game() {
     handleWheelStart,
     handleWheelFinish,
     bet,
+    triggerShotCursor,
   } = useStraightCashGameEngine();
 
   if (phase === "title") {
@@ -38,7 +39,8 @@ export default function Game() {
         onStart={startSplash}
         titleSrc={withBasePath("/assets/titles/warbirds_title.png")}
         backgroundColor={SKY_COLOR}
-        cursor={DEFAULT_CURSOR}
+        cursor={ui.cursor}
+        onShot={triggerShotCursor}
       />
     );
   }
@@ -50,6 +52,7 @@ export default function Game() {
   return (
     <GameUI
       cursor={ui.cursor}
+      onShot={triggerShotCursor}
       canvasRef={canvasRef}
       handleClick={handleClick}
       handleContext={handleContext}


### PR DESCRIPTION
## Summary
- add shot cursor constant
- expose a function to briefly swap to the shot cursor
- apply the crosshair cursor for all clickable elements
- trigger the shot cursor on click to keep the lightgun feel
- revert warbirds game to previous behavior

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688207770b80832b870cc583133dbb22