### PR TITLE
Add reel auto-stop and payout nudge

### DIFF
--- a/src/games/straightcash/components/GameUI.tsx
+++ b/src/games/straightcash/components/GameUI.tsx
@@ -20,6 +20,7 @@ export interface GameUIProps {
   showDie: boolean[];
   handleReelClick: (index: number, e: React.MouseEvent<HTMLDivElement>) => void;
   onSpinEnd: (index: number, result: string) => void;
+  forcedResults: (string | null)[];
   wheelSpinning: boolean;
   onWheelFinish: (reward: string) => void;
   wheelReady: boolean;
@@ -39,6 +40,7 @@ export default function GameUI({
   showDie,
   handleReelClick,
   onSpinEnd,
+  forcedResults,
   wheelSpinning,
   onWheelFinish,
   wheelReady,
@@ -101,6 +103,7 @@ export default function GameUI({
             showDie={showDie[i]}
             onStop={(e) => handleReelClick(i, e)}
             onSpinEnd={(result) => onSpinEnd(i, result)}
+            stopResult={forcedResults[i] ?? undefined}
             cursor={cursor}
           />
         ))}

--- a/src/games/straightcash/components/Reel.tsx
+++ b/src/games/straightcash/components/Reel.tsx
@@ -14,6 +14,7 @@ export interface ReelProps {
   onStop: (e: React.MouseEvent<HTMLDivElement>) => void;
   onSpinEnd?: (result: string) => void;
   cursor: string;
+  stopResult?: string | null;
 }
 
 const ITEM_SIZE = 120;
@@ -26,6 +27,7 @@ export const Reel: React.FC<ReelProps> = ({
   onStop,
   onSpinEnd,
   cursor,
+  stopResult,
 }) => {
   const { assetRefs, ready } = useStraightCashAssets();
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -69,6 +71,13 @@ export const Reel: React.FC<ReelProps> = ({
 
   const [index, setIndex] = useState(0);
   const prevSpinning = useRef(spinning);
+
+  useEffect(() => {
+    if (!spinning && stopResult && items.length > 0) {
+      const idx = items.findIndex((it) => it.rank === stopResult);
+      if (idx >= 0) setIndex(idx);
+    }
+  }, [spinning, stopResult, items]);
   useEffect(() => {
     if (!showDie) return;
     const ctx = canvasRef.current?.getContext("2d");

--- a/src/games/straightcash/index.tsx
+++ b/src/games/straightcash/index.tsx
@@ -25,6 +25,7 @@ export default function Game() {
     dieActive,
     handleReelClick,
     handleSpinEnd,
+    forcedResults,
     wheelSpinning,
     wheelReady,
     handleWheelStart,
@@ -62,6 +63,7 @@ export default function Game() {
       showDie={dieActive}
       handleReelClick={handleReelClick}
       onSpinEnd={handleSpinEnd}
+      forcedResults={forcedResults}
       wheelSpinning={wheelSpinning}
       wheelReady={wheelReady}
       onWheelStart={handleWheelStart}


### PR DESCRIPTION
## Summary
- auto stop reels at random slots after 30s of inactivity
- allow forcing reel result display
- track spin start time
- slightly randomize payout totals

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68820b340ae0832bbb058e82fe85f6e6