### PR TITLE
Add post-score return and reset UI

### DIFF
--- a/src/games/straightcash/components/ScoreSplash.tsx
+++ b/src/games/straightcash/components/ScoreSplash.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect } from "react";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import { SKY_COLOR } from "../constants";
+
+export interface ScoreSplashProps {
+  reward: string | number | null;
+  onReset: () => void;
+  autoReturnMs?: number;
+}
+
+export default function ScoreSplash({ reward, onReset, autoReturnMs = 3000 }: ScoreSplashProps) {
+  useEffect(() => {
+    const id = window.setTimeout(onReset, autoReturnMs);
+    return () => window.clearTimeout(id);
+  }, [onReset, autoReturnMs]);
+
+  return (
+    <Box
+      position="relative"
+      width="100vw"
+      height="100dvh"
+      sx={{ backgroundColor: SKY_COLOR }}
+      display="flex"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+      onClick={onReset}
+    >
+      <Typography variant="h3" color="white" sx={{ mb: 2 }}>
+        {reward != null ? `Reward: ${reward}` : ""}
+      </Typography>
+      <Button variant="contained" onClick={onReset}>
+        Reset
+      </Button>
+    </Box>
+  );
+}

--- a/src/games/straightcash/index.tsx
+++ b/src/games/straightcash/index.tsx
@@ -6,6 +6,7 @@ import { withBasePath } from "@/utils/basePath";
 import TitleSplash from "./components/TitleSplash";
 import GameUI from "./components/GameUI";
 import ReadyGoSplash from "./components/ReadyGoSplash";
+import ScoreSplash from "./components/ScoreSplash";
 import useStraightCashGameEngine from "./hooks/useStraightCashGameEngine";
 
 export default function Game() {
@@ -31,6 +32,7 @@ export default function Game() {
     handleWheelStart,
     handleWheelFinish,
     bet,
+    scoreReward,
     triggerShotCursor,
   } = useStraightCashGameEngine();
 
@@ -48,6 +50,10 @@ export default function Game() {
 
   if (phase === "ready") {
     return <ReadyGoSplash phase="ready" countdown={countdown} />;
+  }
+
+  if (phase === "score") {
+    return <ScoreSplash reward={scoreReward} onReset={resetGame} />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- trigger new `score` phase in the Straight Cash game
- add auto-return logic with a timer
- display `ScoreSplash` overlay after payouts or wheel rewards

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68820d32cef4832b84271ca1005da4b1