### PR TITLE
Fix StraightCash initial payout

### DIFF
--- a/src/games/straightcash/hooks/useStraightCashGameEngine.ts
+++ b/src/games/straightcash/hooks/useStraightCashGameEngine.ts
@@ -337,7 +337,7 @@ export default function useStraightCashGameEngine() {
   }, [phase, resetGame]);
 
   useEffect(() => {
-    if (spinning.every((s) => !s)) {
+    if (spinning.every((s) => !s) && spinStartRef.current !== null) {
       const activeIndices = [0, 1, 2].filter((i) => !isReelDisabled(i));
       if (activeIndices.every((i) => reelResults[i])) {
         setWheelReady(true);


### PR DESCRIPTION
## Summary
- fix payout effect to only run after a spin has started

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688212d1c228832bb1b4ac096a33b1aa