### PR TITLE
Fix disabled reels stop timing

### DIFF
--- a/src/games/straightcash/hooks/useStraightCashGameEngine.ts
+++ b/src/games/straightcash/hooks/useStraightCashGameEngine.ts
@@ -241,9 +241,24 @@ export default function useStraightCashGameEngine() {
           return arr;
         });
         stopReel(index);
+
+        // stop disabled reels if this was the last active reel
+        const upcomingSpinning = spinning.map((s, i) =>
+          i === index ? false : s
+        );
+        const anyActiveSpinning = upcomingSpinning.some(
+          (spin, i) => !isReelDisabled(i) && spin
+        );
+        if (!anyActiveSpinning) {
+          for (let i = 0; i < upcomingSpinning.length; i++) {
+            if (isReelDisabled(i) && upcomingSpinning[i]) {
+              stopReel(i);
+            }
+          }
+        }
       }
     },
-    [locked, dieActive, stopReel]
+    [locked, dieActive, stopReel, spinning, isReelDisabled]
   );
 
   const startSpins = useCallback(


### PR DESCRIPTION
## Summary
- stop disabled reels once the last active reel is clicked

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688214e39878832b855133cc9ed71f51