### PR TITLE
Don't exit to title after StraightCash round

### DIFF
--- a/src/games/straightcash/hooks/useStraightCashGameEngine.ts
+++ b/src/games/straightcash/hooks/useStraightCashGameEngine.ts
@@ -298,6 +298,26 @@ export default function useStraightCashGameEngine() {
     textLabels.current = [];
   }, [audioMgr, slideKeys]);
 
+  const resetRound = useCallback(() => {
+    setPhase("playing");
+    setReelPos([0, 0, 0]);
+    setSpinSpeed(0);
+    setLocked([false, false, false]);
+    setSpinning([false, false, false]);
+    setReelClicks([null, null, null]);
+    setDieActive([false, false, false]);
+    autoStopRefs.current.forEach((t) => {
+      if (t) clearTimeout(t);
+    });
+    autoStopRefs.current = [null, null, null];
+    spinStartRef.current = null;
+    setForcedResults([null, null, null]);
+    setWheelReady(false);
+    audioMgr.pause("wheelSpinSfx");
+    slideKeys.forEach((k) => audioMgr.pause(k));
+    textLabels.current = [];
+  }, [audioMgr, slideKeys]);
+
   // play sliding sounds while any reel spins
   useEffect(() => {
     if (spinning.some((s) => s)) {
@@ -331,10 +351,10 @@ export default function useStraightCashGameEngine() {
 
   useEffect(() => {
     if (phase === "score") {
-      const id = window.setTimeout(() => resetGame(), 3000);
+      const id = window.setTimeout(() => resetRound(), 3000);
       return () => window.clearTimeout(id);
     }
-  }, [phase, resetGame]);
+  }, [phase, resetRound]);
 
   useEffect(() => {
     if (spinning.every((s) => !s) && spinStartRef.current !== null) {
@@ -408,6 +428,7 @@ export default function useStraightCashGameEngine() {
     handleClick,
     handleContext,
     resetGame,
+    resetRound,
     getImg,
     startSplash,
     startSpins,

--- a/src/games/straightcash/index.tsx
+++ b/src/games/straightcash/index.tsx
@@ -17,7 +17,7 @@ export default function Game() {
     canvasRef,
     handleClick,
     handleContext,
-    resetGame,
+    resetRound,
     getImg,
     startSplash,
     startSpins,
@@ -53,7 +53,7 @@ export default function Game() {
   }
 
   if (phase === "score") {
-    return <ScoreSplash reward={scoreReward} onReset={resetGame} />;
+    return <ScoreSplash reward={scoreReward} onReset={resetRound} />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- keep user on the reels HUD after a StraightCash round ends
- introduce `resetRound` logic
- use `resetRound` when dismissing `ScoreSplash`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688214b3a088832b86ffc61568838c39