### PR TITLE
Randomize first reel position

### DIFF
--- a/src/games/straightcash/components/Reel.tsx
+++ b/src/games/straightcash/components/Reel.tsx
@@ -70,7 +70,17 @@ export const Reel: React.FC<ReelProps> = ({
   }, [ready, assetRefs]);
 
   const [index, setIndex] = useState(0);
+  const initializedRef = useRef(false);
   const prevSpinning = useRef(spinning);
+
+  // Set a random starting position for the very first spin
+  useEffect(() => {
+    if (items.length > 0 && !initializedRef.current) {
+      const idx = Math.floor(Math.random() * items.length);
+      setIndex(idx);
+      initializedRef.current = true;
+    }
+  }, [items]);
 
   useEffect(() => {
     if (!spinning && stopResult && items.length > 0) {


### PR DESCRIPTION
## Summary
- initialize the reel component with a random index when assets load
- preserve the index across spins so subsequent spins start from the last result

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68821539a344832bacd61f3d0afcb068