### PR TITLE
Fix splash countdown rendering

### DIFF
--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -3243,6 +3243,28 @@ export function useGameEngine() {
     }
   }, [phase, initLoop]);
 
+  // ─── SIMPLE LOOP FOR READY/GO SPLASH ──────────────────────────────────────
+  useEffect(() => {
+    if (phase === "ready" || phase === "go") {
+      const canvas = canvasRef.current;
+      const ctx = canvas?.getContext("2d");
+      if (!canvas || !ctx) return;
+      let raf: number;
+      const render = () => {
+        ctx.fillStyle = SKY_COLOR;
+        ctx.fillRect(0, 0, dims.width, dims.height);
+        state.current.textLabels = drawTextLabels({
+          textLabels: state.current.textLabels,
+          ctx,
+          cull: true,
+        });
+        raf = requestAnimationFrame(render);
+      };
+      render();
+      return () => cancelAnimationFrame(raf);
+    }
+  }, [phase, dims]);
+
   // ─── CLICK TO FLAP & FIRE ─────────────────────────────────────────────────
   const handleClick = (e: React.MouseEvent) => {
     // out of play or no ammo → reload flash


### PR DESCRIPTION
## Summary
- display countdown during READY/GO phases by running a simple loop

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886852d62a8832ba6264b968ef71803