### PR TITLE
Fix enemy counter asset path

### DIFF
--- a/src/games/warbirds/components/GameUI.tsx
+++ b/src/games/warbirds/components/GameUI.tsx
@@ -152,7 +152,7 @@ export function GameUI({
         >
           <Box
             component="img"
-            src={ENEMY_COLORS[0]}
+            src={withBasePath(ENEMY_COLORS[0])}
             width={48}
             height={48}
             sx={{ mr: 2 }}


### PR DESCRIPTION
## Summary
- use `withBasePath` when displaying the enemy-plane counter image

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886a30d7af4832b867f91aa4649a23d