### PR TITLE
Add mp3 fallback test

### DIFF
--- a/src/utils/__tests__/audio.test.ts
+++ b/src/utils/__tests__/audio.test.ts
@@ -72,4 +72,19 @@ describe('audio utils', () => {
     expect(() => pauseAudio(undefined)).not.toThrow();
     expect(() => rewindAndPlayAudio(undefined)).not.toThrow();
   });
+
+  test('rewindAndPlayAudio switches to mp3 when ogg unsupported', () => {
+    const audioElement = document.createElement('audio');
+    audioElement.play = jest.fn();
+    audioElement.canPlayType = jest.fn((type: string) => {
+      if (type === 'audio/ogg') return '';
+      if (type === 'audio/mpeg') return 'maybe';
+      return '';
+    });
+    const ref: RefObject<HTMLAudioElement> = { current: audioElement };
+
+    rewindAndPlayAudio(ref, '/sound.ogg');
+
+    expect(audioElement.src.endsWith('/sound.mp3')).toBe(true);
+  });
 });

--- a/src/utils/audio.ts
+++ b/src/utils/audio.ts
@@ -18,9 +18,40 @@ export const pauseAudio = (audioRef?: RefObject<HTMLAudioElement | null>) => {
  */
 export const rewindAndPlayAudio = (
   audioRef?: RefObject<HTMLAudioElement | null>,
-  options: { loop?: boolean; volume?: number } = {}
+  srcOrOptions?: string | { loop?: boolean; volume?: number },
+  maybeOptions: { loop?: boolean; volume?: number } = {}
 ) => {
   if (!audioRef || !audioRef.current) return;
+
+  let src: string | undefined;
+  let options: { loop?: boolean; volume?: number };
+
+  if (typeof srcOrOptions === "string") {
+    src = srcOrOptions;
+    options = maybeOptions;
+  } else {
+    options = srcOrOptions || {};
+  }
+
+  if (src) {
+    const ext = src.split(".").pop()?.toLowerCase() ?? "";
+    const mime = ext === "mp3" ? "audio/mpeg" : `audio/${ext}`;
+
+    if (
+      audioRef.current.canPlayType &&
+      audioRef.current.canPlayType(mime) === "" &&
+      ext !== "mp3" &&
+      audioRef.current.canPlayType("audio/mpeg") !== ""
+    ) {
+      src = src.replace(/\.[^/.]+$/, ".mp3");
+    }
+
+    audioRef.current.src = src;
+    if (audioRef.current.load) {
+      audioRef.current.load();
+    }
+  }
+
   if (options.loop) {
     audioRef.current.loop = true;
   } else {


### PR DESCRIPTION
## Summary
- allow `rewindAndPlayAudio` to accept a source URL and swap to `.mp3` when the browser can't play `.ogg`
- test the `.ogg` to `.mp3` fallback logic

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886a353edd4832bb3e93e82428c1098