### PR TITLE
Fix warbirds phase reset

### DIFF
--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -986,6 +986,8 @@ export function useGameEngine() {
     canvas.height = height;
 
     resetState();
+    // ensure we stay in the playing phase after resetting state
+    state.current.phase = "playing";
 
     // flight hum
     play("flightSfx");


### PR DESCRIPTION
## Summary
- ensure game engine stays in the `playing` phase when starting the main loop

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: cannot run TypeScript compiler)*

------
https://chatgpt.com/codex/tasks/task_e_6886a512e0f4832bad1505b2be89ded9