### PR TITLE
Fix countdown after title splash

### DIFF
--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -3261,7 +3261,7 @@ export function useGameEngine() {
       render();
       return () => cancelAnimationFrame(raf);
     }
-  }, [ui.phase, dims]);
+  }, [ui.phase, dims, canvasRef.current]);
 
   // ─── CLICK TO FLAP & FIRE ─────────────────────────────────────────────────
   const handleClick = (e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary
- keep rendering loop in sync when the canvas ref appears

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887988a2a34832b9e31ba87fdb54ea4