### PR TITLE
Fix warbirds countdown on first start

### DIFF
--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -132,7 +132,7 @@ export function useGameEngine() {
   const { play, pause } = audioMgr;
 
   const assetMgr: AssetMgr = useGameAssets();
-  const { getImg } = assetMgr;
+  const { getImg, ready: assetsReady } = assetMgr;
 
   // ─── WINDOW RESIZE ────────────────────────────────────────────────────────
   const dims = useWindowSize();
@@ -3387,6 +3387,7 @@ export function useGameEngine() {
     isActive,
     resetGame,
     resetState,
+    assetsReady,
   };
 }
 

--- a/src/games/warbirds/index.tsx
+++ b/src/games/warbirds/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { DEFAULT_CURSOR, SKY_COLOR } from "./constants";
 import { withBasePath } from "@/utils/basePath";
 import { TitleSplash } from "./components/TitleSplash";
@@ -18,7 +18,25 @@ export default function Game() {
     resetGame,
     getImg,
     startSplash,
+    assetsReady,
   } = engine;
+
+  const [startRequested, setStartRequested] = useState(false);
+
+  const handleStart = useCallback(() => {
+    if (assetsReady) {
+      startSplash();
+    } else {
+      setStartRequested(true);
+    }
+  }, [assetsReady, startSplash]);
+
+  useEffect(() => {
+    if (assetsReady && startRequested) {
+      startSplash();
+      setStartRequested(false);
+    }
+  }, [assetsReady, startRequested, startSplash]);
 
   const { phase } = ui;
 
@@ -26,7 +44,7 @@ export default function Game() {
   if (phase === "title") {
     return (
       <TitleSplash
-        onStart={startSplash}
+        onStart={handleStart}
         titleSrc={withBasePath("/assets/titles/warbirds_title.png")}
         backgroundColor={SKY_COLOR}
         cursor={DEFAULT_CURSOR}


### PR DESCRIPTION
## Summary
- expose `assetsReady` from `useGameEngine`
- delay start of Warbirds until assets are ready

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run -s lint` *(fails: next not found)*
- `npm run -s build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aa557637c832b9e5f5f2655189536