### PR TITLE
Fix countdown after title screen in Warbirds

### DIFF
--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -3276,7 +3276,7 @@ export function useGameEngine() {
       render();
       return () => cancelAnimationFrame(raf);
     }
-  }, [ui.phase, dims]);
+  }, [ui.phase, dims, canvasRef.current]);
 
   // ─── CLICK TO FLAP & FIRE ─────────────────────────────────────────────────
   const handleClick = (e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary
- ensure the ready/go splash loop runs once the canvas is mounted

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aa557637c832b9e5f5f2655189536