### PR TITLE
Use red dice for Reel overlay

### DIFF
--- a/src/games/straightcash/components/Reel.tsx
+++ b/src/games/straightcash/components/Reel.tsx
@@ -96,7 +96,7 @@ export const Reel: React.FC<ReelProps> = ({
     let frame = 0;
     let id: number;
     const draw = () => {
-      const img = diceImgs[`White_border${frame + 1}`];
+      const img = diceImgs[`Red_border${frame + 1}`];
       if (img) {
         ctx.clearRect(0, 0, 32, 32);
         ctx.drawImage(img, 0, 0, 32, 32);


### PR DESCRIPTION
## Summary
- update Reel overlay animation to use red dice images

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ac59d10b8832b861117990f09cbd4