### PR TITLE
Add tests for withBasePath

### DIFF
--- a/src/utils/__tests__/basePath.test.ts
+++ b/src/utils/__tests__/basePath.test.ts
@@ -1,0 +1,24 @@
+// Tests for withBasePath utility
+
+describe('withBasePath', () => {
+  const ORIGINAL_ENV = process.env.NEXT_PUBLIC_BASE_PATH;
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_BASE_PATH = ORIGINAL_ENV;
+    jest.resetModules();
+  });
+
+  test('returns path unchanged when BASE_PATH is empty', async () => {
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+    jest.resetModules();
+    const { withBasePath } = await import('../basePath');
+    expect(withBasePath('/foo')).toBe('/foo');
+  });
+
+  test('prefixes path when BASE_PATH is set', async () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = '/base';
+    jest.resetModules();
+    const { withBasePath } = await import('../basePath');
+    expect(withBasePath('/foo')).toBe('/base/foo');
+  });
+});


### PR DESCRIPTION
## Summary
- test withBasePath utility across base path scenarios

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ac642564c832b85ca54e6a82ae4b5