### PR TITLE
Fix wheel payout multiplier

### DIFF
--- a/src/games/straightcash/hooks/useStraightCashGameEngine.ts
+++ b/src/games/straightcash/hooks/useStraightCashGameEngine.ts
@@ -481,14 +481,15 @@ export default function useStraightCashGameEngine() {
       audioMgr.pause("wheelSpinSfx");
       const numeric = parseInt(reward, 10);
       if (!Number.isNaN(numeric)) {
-        setTokens((t) => t + numeric);
-        setScoreReward(numeric);
+        const payout = numeric * bet * tokenValue;
+        setTokens((t) => t + payout);
+        setScoreReward(payout);
       } else {
         setScoreReward(reward);
       }
       setPhase("score");
     },
-    [audioMgr]
+    [audioMgr, bet, tokenValue]
   );
 
   return {


### PR DESCRIPTION
## Summary
- multiply numeric wheel rewards by `bet` and `tokenValue`

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688ac5a93fc8832b89e829ef557ee2dd