### PR TITLE
Persist bet denom and tokens

### DIFF
--- a/src/games/straightcash/components/GameUI.tsx
+++ b/src/games/straightcash/components/GameUI.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import ToggleButton from "@mui/material/ToggleButton";
@@ -26,6 +26,8 @@ export interface GameUIProps {
   wheelReady: boolean;
   onWheelStart: () => void;
   bet: number;
+  tokenValue: number;
+  setTokenValue: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export default function GameUI({
@@ -46,8 +48,9 @@ export default function GameUI({
   wheelReady,
   onWheelStart,
   bet,
+  tokenValue,
+  setTokenValue,
 }: GameUIProps) {
-  const [tokenValue, setTokenValue] = useState<number>(1);
 
   const handleBet = (amount: number) => {
     startSpins(amount, tokenValue);

--- a/src/games/straightcash/hooks/useStraightCashGameEngine.ts
+++ b/src/games/straightcash/hooks/useStraightCashGameEngine.ts
@@ -521,6 +521,7 @@ export default function useStraightCashGameEngine() {
     bet,
     tokens,
     tokenValue,
+    setTokenValue,
     setReelPos,
     setSpinSpeed,
     setLocked,

--- a/src/games/straightcash/index.tsx
+++ b/src/games/straightcash/index.tsx
@@ -29,6 +29,8 @@ export default function Game() {
     handleWheelStart,
     handleWheelFinish,
     bet,
+    tokenValue,
+    setTokenValue,
     scoreReward,
     triggerShotCursor,
   } = useStraightCashGameEngine();
@@ -69,6 +71,8 @@ export default function Game() {
       onWheelStart={handleWheelStart}
       onWheelFinish={handleWheelFinish}
       bet={bet}
+      tokenValue={tokenValue}
+      setTokenValue={setTokenValue}
     />
   );
 }


### PR DESCRIPTION
## Summary
- keep the selected token value across rounds
- expose `setTokenValue` from the game engine
- pass denomination from the engine into the UI

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ac5d939c8832b91542f543bf35c3b