### PR TITLE
Add progressive jackpot payouts

### DIFF
--- a/src/games/straightcash/components/GameUI.tsx
+++ b/src/games/straightcash/components/GameUI.tsx
@@ -5,7 +5,7 @@ import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Reel from "./Reel";
 import BonusWheel from "./BonusWheel";
-import JackpotDisplay from "./JackpotDisplay";
+import JackpotDisplay, { JackpotHandle } from "./JackpotDisplay";
 import { withBasePath } from "@/utils/basePath";
 
 export interface GameUIProps {
@@ -26,6 +26,7 @@ export interface GameUIProps {
   wheelReady: boolean;
   onWheelStart: () => void;
   bet: number;
+  jackpotRef: React.RefObject<JackpotHandle>;
 }
 
 export default function GameUI({
@@ -46,6 +47,7 @@ export default function GameUI({
   wheelReady,
   onWheelStart,
   bet,
+  jackpotRef,
 }: GameUIProps) {
   const [tokenValue, setTokenValue] = useState<number>(1);
 
@@ -72,7 +74,7 @@ export default function GameUI({
       justifyContent="center"
       onClickCapture={onShot}
     >
-      <JackpotDisplay bet={bet} />
+      <JackpotDisplay bet={bet} ref={jackpotRef} />
       <Box position="relative">
         <BonusWheel spinning={wheelSpinning} onFinish={onWheelFinish} />
         {wheelReady && !wheelSpinning && (

--- a/src/games/straightcash/index.tsx
+++ b/src/games/straightcash/index.tsx
@@ -31,6 +31,7 @@ export default function Game() {
     bet,
     scoreReward,
     triggerShotCursor,
+    jackpotRef,
   } = useStraightCashGameEngine();
 
   if (phase === "title") {
@@ -69,6 +70,7 @@ export default function Game() {
       onWheelStart={handleWheelStart}
       onWheelFinish={handleWheelFinish}
       bet={bet}
+      jackpotRef={jackpotRef}
     />
   );
 }


### PR DESCRIPTION
## Summary
- expose jackpot handle via `JackpotDisplay`
- wire jackpot ref through `GameUI` and game engine
- award progressive jackpots when wheel hits Minor/Major/Grand

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_688ac5aecd28832bbe274faf1911a73d