### PR TITLE
Implement nudged bonus wheel payout

### DIFF
--- a/src/games/straightcash/components/BonusWheel.tsx
+++ b/src/games/straightcash/components/BonusWheel.tsx
@@ -77,12 +77,31 @@ export default function BonusWheel({ spinning, onFinish }: BonusWheelProps) {
     const target = Math.floor(Math.random() * REWARDS.length);
     const finalAngle = spins * 360 + target * wedgeSize + wedgeSize / 2;
     const duration = 4000;
+
     setRotation(finalAngle);
-    const nudge = Math.random() * 10 - 5;
+
     const id = setTimeout(() => {
-      setRotation((r) => r + nudge);
-      setTimeout(() => onFinish(REWARDS[target]), 500);
+      let finalIndex = target;
+      if (Math.random() < 0.5) {
+        // 50% chance to adjust to an adjacent wedge
+        const increaseChance = 0.2; // usually decrease payout
+        if (target === 0) {
+          finalIndex = 1;
+        } else if (target === REWARDS.length - 1) {
+          finalIndex = target - 1;
+        } else if (Math.random() < increaseChance) {
+          finalIndex = target + 1;
+        } else {
+          finalIndex = target - 1;
+        }
+
+        const offset = (finalIndex - target) * wedgeSize;
+        setRotation((r) => r + offset);
+      }
+
+      setTimeout(() => onFinish(REWARDS[finalIndex]), 500);
     }, duration);
+
     return () => clearTimeout(id);
   }, [spinning, onFinish]);
 


### PR DESCRIPTION
## Summary
- add randomized wheel nudge to adjacent wedge
- keep nudge skewed towards lower payouts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ac5ba2e28832b95c81a1342f13a93