### PR TITLE
Add text label overlay to Straight Cash

### DIFF
--- a/src/games/straightcash/components/GameUI.tsx
+++ b/src/games/straightcash/components/GameUI.tsx
@@ -141,7 +141,10 @@ export default function GameUI({
         onClick={handleClick}
         onContextMenu={handleContext}
         style={{
-          display: "none",
+          position: "absolute",
+          top: 0,
+          left: 0,
+          display: "block",
           width: "100%",
           height: "100%",
           cursor,

--- a/src/games/straightcash/hooks/useStraightCashGameEngine.ts
+++ b/src/games/straightcash/hooks/useStraightCashGameEngine.ts
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { DEFAULT_CURSOR, SHOT_CURSOR } from "../constants";
 import { AudioMgr } from "@/types/audio";
 import { TextLabel } from "@/types/ui";
+import { drawTextLabels } from "@/utils/ui";
 import useStraightCashAudio from "./useStraightCashAudio";
 
 const REEL_RANKS = [
@@ -423,6 +424,27 @@ export default function useStraightCashGameEngine() {
       return () => window.clearTimeout(id);
     }
   }, [phase, resetRound]);
+
+  // canvas render loop for floating text labels
+  useEffect(() => {
+    if (phase === "playing" || phase === "wheel") {
+      const canvas = canvasRef.current;
+      const ctx = canvas?.getContext("2d");
+      if (!canvas || !ctx) return;
+      let raf: number;
+      const render = () => {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        textLabels.current = drawTextLabels({
+          textLabels: textLabels.current,
+          ctx,
+          cull: true,
+        });
+        raf = requestAnimationFrame(render);
+      };
+      render();
+      return () => cancelAnimationFrame(raf);
+    }
+  }, [phase]);
 
   useEffect(() => {
     if (spinning.every((s) => !s) && spinStartRef.current !== null) {


### PR DESCRIPTION
## Summary
- render floating text labels on a canvas in the Straight Cash engine
- show the canvas overlay in the Straight Cash UI so pop-up values appear

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ac5d3b830832b9e7e9920f6dba05b