### PR TITLE
Trigger shot cursor when reels are clicked

### DIFF
--- a/src/games/straightcash/hooks/useStraightCashGameEngine.ts
+++ b/src/games/straightcash/hooks/useStraightCashGameEngine.ts
@@ -257,6 +257,7 @@ export default function useStraightCashGameEngine() {
 
   const handleReelClick = useCallback(
     (index: number, e: React.MouseEvent<HTMLDivElement>) => {
+      triggerShotCursor();
       const rect = e.currentTarget.getBoundingClientRect();
       const pos = { x: e.clientX - rect.left, y: e.clientY - rect.top };
       setReelClicks((prev) => {


### PR DESCRIPTION
## Summary
- show a shot cursor animation when a reel is clicked

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ac5cd8a28832ba39bf23b2bc47b06