### PR TITLE
Fix README line break

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `src/app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
+This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel. 
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:


### PR DESCRIPTION
## Summary
- join a line in README about `next/font` so the heading appears right after it

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ac62c9740832b8317df9bf2fe8aa7