### PR TITLE
Implement autoReload powerup

### DIFF
--- a/src/constants/powerups.ts
+++ b/src/constants/powerups.ts
@@ -16,6 +16,7 @@ export const POWERUP_TYPES: PowerupType[] = [
   "hourglass",
   "infiniteAmmo",
   "machineGuns",
+  "autoReload",
   "megaducks",
   "napalm",
   "magnet",
@@ -69,6 +70,9 @@ export const CANNONBALL_SPEED = 12; // pixels per frame
 export const LASER_BEAM_BURST_COUNT = 15; // number of beams per burst
 export const LASER_BEAM_SHOT_INTERVAL = 2; // frames between beams in burst
 export const LASER_BEAM_SPEED = 20; // pixels per frame
+
+// auto reload powerup constants
+export const AUTO_RELOAD_INTERVAL = 15; // frames per ammo refill
 
 // homing missile related constants
 export const SCORE_HOMING_BONUS = 100;

--- a/src/games/warbirds/hooks/useGameAssets.ts
+++ b/src/games/warbirds/hooks/useGameAssets.ts
@@ -184,6 +184,9 @@ export function useGameAssets(): {
     assetRefs.current.powerupImgs.machineGuns = loadImg(
       "/assets/powerups/machine_guns.png"
     );
+    assetRefs.current.powerupImgs.autoReload = loadImg(
+      "/assets/powerups/autoReload.png"
+    );
     assetRefs.current.powerupImgs.shrink = loadImg(
       "/assets/powerups/shrink_effect.png"
     );

--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -50,6 +50,7 @@ import {
   SPRAY_COUNT,
   SPRAY_SPREAD,
   SPRAY_INTERVAL,
+  AUTO_RELOAD_INTERVAL,
 } from "@/constants/powerups";
 import { SCORE_DIGIT_WIDTH, SCORE_DIGIT_HEIGHT } from "@/constants/ui";
 import {
@@ -578,6 +579,10 @@ export function useGameEngine() {
             // reset burst count and cooldown
             state.current.burstRemaining = MACHINE_GUN_BURST_COUNT;
             state.current.burstCooldown = 0;
+          } else if (p.type === "autoReload") {
+            state.current.activePowerups.autoReload.expires =
+              state.current.frameCount + POWERUP_DURATION;
+            play("powerupSfx");
           } else if (p.type === "shrink") {
             state.current.activePowerups.shrink.expires =
               state.current.frameCount + POWERUP_DURATION;
@@ -1222,6 +1227,16 @@ export function useGameEngine() {
             state.current.burstCooldown--;
           }
         }
+      }
+
+      // ─── AUTO RELOAD ───────────────────────────────────────────────
+      if (
+        state.current.isActive("autoReload", state.current.frameCount) &&
+        state.current.ammo < MAX_AMMO &&
+        state.current.frameCount % AUTO_RELOAD_INTERVAL === 0
+      ) {
+        state.current.ammo = Math.min(MAX_AMMO, state.current.ammo + 1);
+        play("reloadSfx");
       }
 
       // advance player prop

--- a/src/games/warbirds/utils.ts
+++ b/src/games/warbirds/utils.ts
@@ -35,6 +35,7 @@ export function initState(
     hourglass: { expires: 0 },
     infiniteAmmo: { expires: 0 },
     machineGuns: { expires: 0 },
+    autoReload: { expires: 0 },
     megaducks: { expires: 0 },
     magnet: { expires: 0 },
     napalm: { expires: 0 },

--- a/src/types/objects.ts
+++ b/src/types/objects.ts
@@ -12,6 +12,7 @@ export type PowerupType =
   | "hourglass"
   | "infiniteAmmo"
   | "machineGuns"
+  | "autoReload"
   | "megaducks"
   | "napalm"
   | "magnet"


### PR DESCRIPTION
## Summary
- add `autoReload` powerup type
- load new sprite and map it to assets
- handle pickup and duration for `autoReload`
- implement automatic ammo reload behaviour
- add new constant `AUTO_RELOAD_INTERVAL`
- remove placeholder asset

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ae5d9b828832b9d95325be45cbc47