### PR TITLE
feat(zombiefish): add basic audio manager

### DIFF
--- a/src/games/zombiefish/hooks/useGameAudio.ts
+++ b/src/games/zombiefish/hooks/useGameAudio.ts
@@ -1,158 +1,58 @@
-// hooks/useGameAudio.ts
-import { useCallback, useMemo, RefObject } from "react";
-import { useAudio } from "@/hooks/useAudio";
+import { useCallback, useMemo } from "react";
 import { AudioMgr } from "@/types/audio";
-import { rewindAndPlayAudio, pauseAudio } from "@/utils/audio";
 
 /**
- * Provides an audio manager for playing and pausing game SFX.
- * All returned methods are memoized to ensure stable references.
- *
- * @returns {AudioMgr} Object with play, pause, and pauseAll methods.
+ * Simple audio manager for Zombie Fish.
+ * Loads core game sounds and exposes play / pause helpers.
  */
 export function useGameAudio(): AudioMgr {
-  // ─── AUDIO REFS ─────────────────────────────────────────────────────────
-  const artillerySfx = useAudio("/audio/whistle_fall.ogg", true);
-  const artilleryExplodeSfx = useAudio("/audio/explosionCrunch_000.ogg");
-  const artillerySplashSfx = useAudio("/audio/splash.ogg");
-  const beepSfx = useAudio("/audio/drop_003.ogg");
-  const boopSfx = useAudio("/audio/drop_004.ogg");
-  const bombSfx = useAudio("/audio/explosionCrunch_004.ogg");
-  const cannonballSfx = useAudio("/audio/laserRetro_000.ogg");
-  const crashSfx = useAudio("/audio/explosionCrunch_002.ogg");
-  const duckSfx = useAudio("/audio/select_003.ogg");
-  const enemyHitSfx = useAudio("/audio/laser9.ogg");
-  const flapSfx = useAudio("/audio/click_001.ogg");
-  const flightSfx = useAudio("/audio/engineCircular_001.ogg", true);
-  const freezeSfx = useAudio("/audio/freeze.ogg");
-  const gameOverSfx = useAudio("/audio/select_005.ogg");
-  const groundTouchSfx = useAudio("/audio/explosionCrunch_002.ogg");
-  const homingExplSfx = useAudio("/audio/explosionCrunch_001.ogg");
-  const medalSfx = useAudio("/audio/confirmation_003.ogg");
-  const napalmExplodeSfx = useAudio("/audio/explosionCrunch_000.ogg");
-  const powerupSfx = useAudio("/audio/powerUp8.ogg");
-  const reloadSfx = useAudio("/audio/scratch_003.ogg");
-  const shieldSfx = useAudio("/audio/forceField_002.ogg");
-  const shrinkSfx = useAudio("/audio/phaserDown1.ogg");
-  const skullSfx = useAudio("/audio/lowDown.ogg");
-  const laserBeamFireSfx = useAudio("/audio/laserSmall_001.ogg");
-  const shotSfx = useAudio("/audio/laser4.ogg");
-  const thunderSfx = useAudio("/audio/thunderstrike.ogg");
-  const thrusterSfx = useAudio("/audio/thrusterFire_000.ogg", true);
-  const whooshSfx = useAudio("/audio/whoosh.ogg", true);
+  // Load audio clips via <audio> elements
+  const audios = useMemo<Record<string, HTMLAudioElement>>(() => {
+    if (typeof Audio === "undefined") return {} as Record<string, HTMLAudioElement>;
 
-  // ─── AUDIO REFS OBJECT (MEMOIZED) ───────────────────────────────────────
-  /**
-   * Maps audio keys to their respective refs.
-   * Memoized so its reference is stable unless dependencies change.
-   */
-  const audioRefs = useMemo<Record<string, RefObject<HTMLAudioElement | null>>>(
-    () => ({
-      artillerySfx,
-      artilleryExplodeSfx,
-      artillerySplashSfx,
-      beepSfx,
-      boopSfx,
-      bombSfx,
-      cannonballSfx,
-      crashSfx,
-      duckSfx,
-      enemyHitSfx,
-      flapSfx,
-      freezeSfx,
-      flightSfx,
-      gameOverSfx,
-      groundTouchSfx,
-      homingExplSfx,
-      medalSfx,
-      napalmExplodeSfx,
-      powerupSfx,
-      reloadSfx,
-      shieldSfx,
-      shrinkSfx,
-      skullSfx,
-      laserBeamFireSfx,
-      shotSfx,
-      thunderSfx,
-      thrusterSfx,
-      whooshSfx,
-    }),
-    [
-      artillerySfx,
-      artilleryExplodeSfx,
-      artillerySplashSfx,
-      beepSfx,
-      boopSfx,
-      bombSfx,
-      cannonballSfx,
-      crashSfx,
-      duckSfx,
-      enemyHitSfx,
-      flapSfx,
-      freezeSfx,
-      flightSfx,
-      gameOverSfx,
-      groundTouchSfx,
-      homingExplSfx,
-      medalSfx,
-      napalmExplodeSfx,
-      powerupSfx,
-      reloadSfx,
-      shieldSfx,
-      shrinkSfx,
-      skullSfx,
-      laserBeamFireSfx,
-      shotSfx,
-      thunderSfx,
-      thrusterSfx,
-      whooshSfx,
-    ]
-  );
+    const shoot = document.createElement("audio");
+    shoot.src = "/audio/laser4.ogg";
+    shoot.preload = "auto";
 
-  /**
-   * Plays a sound effect by key. Memoized for referential stability.
-   */
+    const hit = document.createElement("audio");
+    hit.src = "/audio/laser9.ogg";
+    hit.preload = "auto";
+
+    const bonus = document.createElement("audio");
+    bonus.src = "/audio/powerUp8.ogg"; // special-fish bonus
+    bonus.preload = "auto";
+
+    return { shoot, hit, bonus };
+  }, []);
+
+  // Play a sound by key
   const play = useCallback(
-    (key: string, options?: { loop?: boolean; volume?: number }) => {
-      const audioRef = audioRefs[key];
-      if (audioRef && audioRef.current) {
-        rewindAndPlayAudio(
-          audioRef,
-          options || {
-            loop: audioRef.current.loop,
-            volume: audioRef.current.volume,
-          }
-        );
+    (key: string) => {
+      const audio = audios[key];
+      if (audio) {
+        audio.currentTime = 0;
+        void audio.play();
       }
     },
-    [audioRefs]
+    [audios]
   );
 
-  /**
-   * Pauses a sound effect by key. Memoized for referential stability.
-   */
+  // Pause a sound by key
   const pause = useCallback(
     (key: string) => {
-      const audioRef = audioRefs[key];
-      if (audioRef && audioRef.current) {
-        pauseAudio(audioRef);
+      const audio = audios[key];
+      if (audio) {
+        audio.pause();
       }
     },
-    [audioRefs]
+    [audios]
   );
 
-  /**
-   * Pauses all sound effects. Memoized for referential stability.
-   */
+  // Pause all sounds (required by AudioMgr interface)
   const pauseAll = useCallback(() => {
-    Object.values(audioRefs).forEach((ref) => {
-      if (ref.current) {
-        pauseAudio(ref);
-      }
-    });
-  }, [audioRefs]);
+    Object.values(audios).forEach((audio) => audio.pause());
+  }, [audios]);
 
-  // ─── AUDIO MANAGER RETURN ───────────────────────────────────────────────
   return useMemo(
     () => ({
       play,
@@ -162,3 +62,4 @@ export function useGameAudio(): AudioMgr {
     [play, pause, pauseAll]
   );
 }
+


### PR DESCRIPTION
## Summary
- load shoot, hit and bonus clips via HTML audio elements
- expose play and pause controls for game audio

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d88f951b8832b8858cc4730ca961d