### PR TITLE
feat: add zombiefish spawner

### DIFF
--- a/src/games/zombiefish/index.tsx
+++ b/src/games/zombiefish/index.tsx
@@ -5,10 +5,10 @@ import { DEFAULT_CURSOR, SKY_COLOR } from "./constants";
 import { withBasePath } from "@/utils/basePath";
 import { TitleSplash } from "./components/TitleSplash";
 import GameUI from "./components/GameUI";
-import useGameEngine from "./hooks/useGameEngine";
+import useZombiefishEngine from "./hooks/useZombiefishEngine";
 
 export default function Game() {
-  const engine = useGameEngine();
+  const engine = useZombiefishEngine();
 
   const {
     ui,

--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -3,6 +3,21 @@ import type { Dims } from "@/types/ui";
 // Game phases for the simple zombiefish prototype
 export type GamePhase = "title" | "playing" | "gameover";
 
+// Basic fish state tracked by the engine
+export interface Fish {
+  id: number;
+  kind: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  /**
+   * Optional identifier tying fish together when spawned in a group.
+   * Special fish spawn without a groupId.
+   */
+  groupId?: number;
+}
+
 // State exposed to the UI layer
 export interface GameUIState {
   phase: GamePhase;
@@ -17,4 +32,6 @@ export interface GameUIState {
 // Internal game state tracked by the engine
 export interface GameState extends GameUIState {
   dims: Dims;
+  /** Active fish currently in the scene */
+  fish: Fish[];
 }


### PR DESCRIPTION
## Summary
- add useZombiefishEngine hook with spawnFish for grouped and special fish
- track fish state and group IDs in game state
- update game to use new zombiefish engine

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688d8cf1db38832b9321b98f01d4719a