### PR TITLE
feat: skeletonize fish on click

### DIFF
--- a/src/games/zombiefish/hooks/useZombiefishEngine.ts
+++ b/src/games/zombiefish/hooks/useZombiefishEngine.ts
@@ -1,6 +1,8 @@
 import { useRef, useState, useEffect, useCallback } from "react";
 import { useWindowSize } from "@/hooks/useWindowSize";
 import { useGameAssets } from "./useGameAssets";
+import { useAudio } from "@/hooks/useAudio";
+import { rewindAndPlayAudio } from "@/utils/audio";
 import type { GameState, GameUIState, Fish } from "../types";
 
 const GAME_TIME = 60 * 30; // 30 seconds in frames
@@ -14,6 +16,7 @@ export default function useZombiefishEngine() {
 
   // assets
   const { getImg, ready } = useGameAssets();
+  const killSfx = useAudio("/audio/splash.ogg");
 
   // window dimensions
   const dims = useWindowSize();
@@ -68,15 +71,58 @@ export default function useZombiefishEngine() {
     animationFrameRef.current = requestAnimationFrame(loop);
   }, [loop]);
 
-  // handle left click – record a shot and a hit (placeholder)
-  const handleClick = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    const cur = state.current;
-    if (cur.phase !== "playing") return;
-    cur.shots += 1;
-    cur.hits += 1; // TODO: collision detection to determine real hits
-    setUI({ phase: cur.phase, timer: cur.timer, shots: cur.shots, hits: cur.hits });
-  }, []);
+  // handle left click – detect and affect fish
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      const cur = state.current;
+      if (cur.phase !== "playing") return;
+
+      cur.shots += 1;
+      const canvas = canvasRef.current;
+      if (!canvas) {
+        setUI({ phase: cur.phase, timer: cur.timer, shots: cur.shots, hits: cur.hits });
+        return;
+      }
+
+      const rect = canvas.getBoundingClientRect();
+      const x =
+        ((e.clientX - rect.left) / rect.width) * cur.dims.width;
+      const y =
+        ((e.clientY - rect.top) / rect.height) * cur.dims.height;
+
+      for (let i = cur.fish.length - 1; i >= 0; i--) {
+        const f = cur.fish[i];
+        if (
+          x >= f.x &&
+          x <= f.x + FISH_SIZE &&
+          y >= f.y &&
+          y <= f.y + FISH_SIZE
+        ) {
+          cur.hits += 1;
+          if (f.isSkeleton) {
+            f.health = (f.health ?? 0) - 1;
+            if ((f.health ?? 0) <= 0) {
+              cur.fish.splice(i, 1);
+              rewindAndPlayAudio(killSfx);
+            }
+          } else {
+            f.isSkeleton = true;
+            f.health = 1;
+          }
+          break;
+        }
+      }
+
+      setUI({
+        phase: cur.phase,
+        timer: cur.timer,
+        shots: cur.shots,
+        hits: cur.hits,
+      });
+    },
+    [killSfx]
+  );
 
   // suppress context menu
   const handleContext = useCallback((e: React.MouseEvent) => {
@@ -121,6 +167,7 @@ export default function useZombiefishEngine() {
           y,
           vx: baseVx,
           vy: 0,
+          isSkeleton: false,
           ...(groupId !== undefined ? { groupId } : {}),
         } as Fish;
       };
@@ -139,6 +186,7 @@ export default function useZombiefishEngine() {
             vx: baseVx,
             vy: 0,
             groupId,
+            isSkeleton: false,
           });
         });
       } else {

--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -16,6 +16,10 @@ export interface Fish {
    * Special fish spawn without a groupId.
    */
   groupId?: number;
+  /** Whether this fish has turned into a skeleton */
+  isSkeleton?: boolean;
+  /** Remaining health for skeleton fish */
+  health?: number;
 }
 
 // State exposed to the UI layer


### PR DESCRIPTION
## Summary
- track skeleton status and health on zombiefish
- handle click to convert fish into skeletons and kill skeletons with splash sound

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm install --save-dev jest-environment-jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d8e85f1e4832b8b1e14f71aea62df