### PR TITLE
Implement skeleton chase mechanics for zombiefish

### DIFF
--- a/src/games/zombiefish/hooks/useZombiefishEngine.ts
+++ b/src/games/zombiefish/hooks/useZombiefishEngine.ts
@@ -6,6 +6,8 @@ import type { GameState, GameUIState, Fish } from "../types";
 const GAME_TIME = 60 * 30; // 30 seconds in frames
 
 const FISH_SIZE = 128;
+const SKELETON_SPEED = 2;
+const SKELETON_CONVERT_DISTANCE = FISH_SIZE / 2;
 
 export default function useZombiefishEngine() {
   // canvas and animation frame refs
@@ -44,17 +46,64 @@ export default function useZombiefishEngine() {
     state.current.dims = dims;
   }, [dims]);
 
-  // main loop updates timer
+  const updateFish = useCallback(() => {
+    const cur = state.current;
+
+    // move all fish
+    cur.fish.forEach((f) => {
+      f.x += f.vx;
+      f.y += f.vy;
+    });
+
+    // skeleton behavior
+    cur.fish.forEach((s) => {
+      if (s.kind !== "skeleton") return;
+
+      let nearest: Fish | undefined;
+      let nearestDist = Infinity;
+
+      cur.fish.forEach((t) => {
+        if (t.kind === "skeleton") return;
+        const dx = t.x - s.x;
+        const dy = t.y - s.y;
+        const dist2 = dx * dx + dy * dy;
+        if (dist2 < nearestDist) {
+          nearestDist = dist2;
+          nearest = t;
+        }
+      });
+
+      if (nearest) {
+        const dx = nearest.x - s.x;
+        const dy = nearest.y - s.y;
+        const dist = Math.hypot(dx, dy);
+        if (dist > 0) {
+          s.vx = (dx / dist) * SKELETON_SPEED;
+          s.vy = (dy / dist) * SKELETON_SPEED;
+        }
+        if (dist < SKELETON_CONVERT_DISTANCE) {
+          nearest.kind = "skeleton";
+          nearest.health = 2;
+          nearest.vx = 0;
+          nearest.vy = 0;
+          delete nearest.groupId;
+        }
+      }
+    });
+  }, []);
+
+  // main loop updates timer and fish
   const loop = useCallback(() => {
     const cur = state.current;
     if (cur.phase !== "playing") return;
+    updateFish();
     cur.timer = Math.max(0, cur.timer - 1);
     if (cur.timer === 0) {
       cur.phase = "gameover";
     }
     setUI({ phase: cur.phase, timer: cur.timer, shots: cur.shots, hits: cur.hits });
     animationFrameRef.current = requestAnimationFrame(loop);
-  }, []);
+  }, [updateFish]);
 
   // start the game
   const startSplash = useCallback(() => {
@@ -121,6 +170,7 @@ export default function useZombiefishEngine() {
           y,
           vx: baseVx,
           vy: 0,
+          ...(k === "skeleton" ? { health: 2 } : {}),
           ...(groupId !== undefined ? { groupId } : {}),
         } as Fish;
       };

--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -11,6 +11,8 @@ export interface Fish {
   y: number;
   vx: number;
   vy: number;
+  /** Health points, used by skeleton fish. */
+  health?: number;
   /**
    * Optional identifier tying fish together when spawned in a group.
    * Special fish spawn without a groupId.


### PR DESCRIPTION
## Summary
- make fish optionally track health for skeleton state
- update engine: skeletons pursue nearest fish, adjust velocity, and convert victims to skeletons with 2 health

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d8e92f9ec832b8817ed3b1f14ad79