### PR TITLE
feat: add special fish time bonuses

### DIFF
--- a/src/games/zombiefish/hooks/useGameAssets.ts
+++ b/src/games/zombiefish/hooks/useGameAssets.ts
@@ -146,6 +146,24 @@ export function useGameAssets(): {
     assetRefs.current.pctImg = loadImg(
       "/assets/fish/PNG/HUDText/hud_percent.png"
     );
+    assetRefs.current.plusImg = loadImg(
+      "/assets/fish/PNG/HUDText/hud_plus.png"
+    );
+
+    // Generate a simple minus sign dynamically since assets lack one
+    const minusCanvas = document.createElement("canvas");
+    minusCanvas.width = assetRefs.current.plusImg.width || 32;
+    minusCanvas.height = assetRefs.current.plusImg.height || 32;
+    const mctx = minusCanvas.getContext("2d");
+    if (mctx) {
+      mctx.fillStyle = "white";
+      const barHeight = Math.max(1, Math.floor(minusCanvas.height / 5));
+      const y = Math.floor((minusCanvas.height - barHeight) / 2);
+      mctx.fillRect(0, y, minusCanvas.width, barHeight);
+    }
+    const minusImg = new window.Image();
+    minusImg.src = minusCanvas.toDataURL();
+    assetRefs.current.minusImg = minusImg;
 
     // LETTER IMAGES (none provided in assets, but keep key for API parity)
     assetRefs.current.letterImgs = {};

--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -1,4 +1,4 @@
-import type { Dims } from "@/types/ui";
+import type { Dims, TextLabel } from "@/types/ui";
 
 // Game phases for the simple zombiefish prototype
 export type GamePhase = "title" | "playing" | "gameover";
@@ -20,8 +20,6 @@ export interface Fish {
   groupId?: number;
   /** Whether this fish has turned into a skeleton */
   isSkeleton?: boolean;
-  /** Remaining health for skeleton fish */
-  health?: number;
 }
 
 // State exposed to the UI layer
@@ -40,4 +38,6 @@ export interface GameState extends GameUIState {
   dims: Dims;
   /** Active fish currently in the scene */
   fish: Fish[];
+  /** Floating text labels currently displayed */
+  textLabels: TextLabel[];
 }

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -104,6 +104,8 @@ export function newTextLabel(
   const letterImgs = getImg("letterImgs") as Record<string, HTMLImageElement>;
   const numberImgs = getImg("numberImgs") as Record<string, HTMLImageElement>;
   const digitImgs = getImg("digitImgs") as Record<string, HTMLImageElement>;
+  const plusImg = getImg("plusImg") as HTMLImageElement;
+  const minusImg = getImg("minusImg") as HTMLImageElement;
 
   // measure total width, accounting for spaces
   let totalWidth = 0;
@@ -120,7 +122,11 @@ export function newTextLabel(
       imgs.push(null); // push null for space to maintain index
     } else {
       const img =
-        letterImgs[ch.toUpperCase()] || numberImgs[ch] || digitImgs[ch];
+        (ch === "+"
+          ? plusImg
+          : ch === "-"
+          ? minusImg
+          : letterImgs[ch.toUpperCase()] || numberImgs[ch] || digitImgs[ch]);
       if (img) {
         totalWidth += img.width * scale + 2;
         imgs.push(img);


### PR DESCRIPTION
## Summary
- add plus/minus HUD assets for time bonus labels
- support '+' and '-' in text label helper
- implement special fish time modifiers and prevent special fish grouping

## Testing
- `npm run lint`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688d90c3e158832b81369954e0ed8c3c