### PR TITLE
Track shot accuracy for zombiefish

### DIFF
--- a/src/games/zombiefish/components/GameUI.tsx
+++ b/src/games/zombiefish/components/GameUI.tsx
@@ -27,7 +27,7 @@ export function GameUI({
   handleContext,
   resetGame,
 }: GameUIProps) {
-  const { phase, timer, shots, hits } = ui;
+  const { phase, timer, shots, hits, accuracy } = ui;
 
   return (
     <Box position="relative" width="100vw" height="100dvh">
@@ -61,10 +61,12 @@ export function GameUI({
             color: "white",
             fontSize: 48,
             cursor: "pointer",
+            textAlign: "center",
           }}
           onClick={resetGame}
         >
-          Game Over
+          <div>Game Over</div>
+          <div style={{ fontSize: 24 }}>Accuracy: {accuracy.toFixed(0)}%</div>
         </Box>
       )}
     </Box>

--- a/src/games/zombiefish/hooks/useZombiefishEngine.ts
+++ b/src/games/zombiefish/hooks/useZombiefishEngine.ts
@@ -29,6 +29,7 @@ export default function useZombiefishEngine() {
     timer: GAME_TIME,
     shots: 0,
     hits: 0,
+    accuracy: 0,
     dims,
     fish: [],
   });
@@ -42,6 +43,7 @@ export default function useZombiefishEngine() {
     timer: GAME_TIME,
     shots: 0,
     hits: 0,
+    accuracy: 0,
   });
 
   // sync dims when window size changes
@@ -125,7 +127,14 @@ export default function useZombiefishEngine() {
         f.y < height + margin
     );
 
-    setUI({ phase: cur.phase, timer: cur.timer, shots: cur.shots, hits: cur.hits });
+    cur.accuracy = cur.shots > 0 ? (cur.hits / cur.shots) * 100 : 0;
+    setUI({
+      phase: cur.phase,
+      timer: cur.timer,
+      shots: cur.shots,
+      hits: cur.hits,
+      accuracy: cur.accuracy,
+    });
     animationFrameRef.current = requestAnimationFrame(loop);
   }, [updateFish]);
 
@@ -136,7 +145,14 @@ export default function useZombiefishEngine() {
     cur.timer = GAME_TIME;
     cur.shots = 0;
     cur.hits = 0;
-    setUI({ phase: cur.phase, timer: cur.timer, shots: cur.shots, hits: cur.hits });
+    cur.accuracy = 0;
+    setUI({
+      phase: cur.phase,
+      timer: cur.timer,
+      shots: cur.shots,
+      hits: cur.hits,
+      accuracy: cur.accuracy,
+    });
     if (animationFrameRef.current) cancelAnimationFrame(animationFrameRef.current);
     animationFrameRef.current = requestAnimationFrame(loop);
   }, [loop]);
@@ -151,7 +167,14 @@ export default function useZombiefishEngine() {
       cur.shots += 1;
       const canvas = canvasRef.current;
       if (!canvas) {
-        setUI({ phase: cur.phase, timer: cur.timer, shots: cur.shots, hits: cur.hits });
+        cur.accuracy = cur.shots > 0 ? (cur.hits / cur.shots) * 100 : 0;
+        setUI({
+          phase: cur.phase,
+          timer: cur.timer,
+          shots: cur.shots,
+          hits: cur.hits,
+          accuracy: cur.accuracy,
+        });
         return;
       }
 
@@ -184,11 +207,13 @@ export default function useZombiefishEngine() {
         }
       }
 
+      cur.accuracy = cur.shots > 0 ? (cur.hits / cur.shots) * 100 : 0;
       setUI({
         phase: cur.phase,
         timer: cur.timer,
         shots: cur.shots,
         hits: cur.hits,
+        accuracy: cur.accuracy,
       });
     },
     [killSfx]
@@ -206,8 +231,15 @@ export default function useZombiefishEngine() {
     cur.timer = GAME_TIME;
     cur.shots = 0;
     cur.hits = 0;
+    cur.accuracy = 0;
     cur.fish = [];
-    setUI({ phase: cur.phase, timer: cur.timer, shots: cur.shots, hits: cur.hits });
+    setUI({
+      phase: cur.phase,
+      timer: cur.timer,
+      shots: cur.shots,
+      hits: cur.hits,
+      accuracy: cur.accuracy,
+    });
     if (animationFrameRef.current) cancelAnimationFrame(animationFrameRef.current);
   }, []);
 

--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -33,6 +33,8 @@ export interface GameUIState {
   shots: number;
   /** Total number of successful hits */
   hits: number;
+  /** Hit accuracy percentage */
+  accuracy: number;
 }
 
 // Internal game state tracked by the engine


### PR DESCRIPTION
## Summary
- Count shots for each click and hits when fish are struck.
- Track accuracy as `(hits/shots)*100` and expose it through the UI state.
- Display accuracy percentage on the game over screen.

## Testing
- `npm run lint`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found; attempted `npm install -D jest-environment-jsdom` but received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d9125b818832b9372c6cb69815d10