### PR TITLE
Orient fish sprites to velocity

### DIFF
--- a/src/games/zombiefish/hooks/useZombiefishEngine.ts
+++ b/src/games/zombiefish/hooks/useZombiefishEngine.ts
@@ -119,6 +119,11 @@ export default function useZombiefishEngine() {
         }
       }
     });
+
+    // update orientation angle for all fish based on their velocity
+    cur.fish.forEach((f) => {
+      f.angle = Math.atan2(f.vy, Math.abs(f.vx));
+    });
   }, []);
 
   // main loop updates timer and fish
@@ -229,7 +234,13 @@ export default function useZombiefishEngine() {
         f.isSkeleton ? "skeletonImgs" : "fishImgs"
       ) as Record<string, HTMLImageElement>;
       const img = imgMap[f.kind as keyof typeof imgMap];
-      if (img) ctx.drawImage(img, f.x, f.y, FISH_SIZE, FISH_SIZE);
+      if (!img) return;
+      ctx.save();
+      ctx.translate(f.x + FISH_SIZE / 2, f.y + FISH_SIZE / 2);
+      if (f.vx < 0) ctx.scale(-1, 1);
+      ctx.rotate(f.angle);
+      ctx.drawImage(img, -FISH_SIZE / 2, -FISH_SIZE / 2, FISH_SIZE, FISH_SIZE);
+      ctx.restore();
     });
 
     // cull fish that have moved completely off-screen
@@ -254,7 +265,13 @@ export default function useZombiefishEngine() {
           f.isSkeleton ? "skeletonImgs" : "fishImgs"
         ) as Record<string, HTMLImageElement>;
         const img = imgMap[f.kind as keyof typeof imgMap];
-        if (img) ctx.drawImage(img, f.x, f.y, FISH_SIZE, FISH_SIZE);
+        if (!img) return;
+        ctx.save();
+        ctx.translate(f.x + FISH_SIZE / 2, f.y + FISH_SIZE / 2);
+        if (f.vx < 0) ctx.scale(-1, 1);
+        ctx.rotate(f.angle);
+        ctx.drawImage(img, -FISH_SIZE / 2, -FISH_SIZE / 2, FISH_SIZE, FISH_SIZE);
+        ctx.restore();
       });
 
       cur.textLabels = drawTextLabels({
@@ -464,6 +481,7 @@ export default function useZombiefishEngine() {
           y,
           vx: baseVx,
           vy: 0,
+          angle: 0,
           ...(k === "skeleton" ? { health: 2 } : {}),
           isSkeleton: k === "skeleton",
           ...(groupId !== undefined ? { groupId } : {}),
@@ -483,6 +501,7 @@ export default function useZombiefishEngine() {
             y,
             vx: baseVx,
             vy: 0,
+            angle: 0,
             groupId,
             isSkeleton: false,
           });

--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -11,6 +11,8 @@ export interface Fish {
   y: number;
   vx: number;
   vy: number;
+  /** Current drawing angle in radians based on velocity. */
+  angle: number;
   /** Health points, used by skeleton fish. */
   health?: number;
   /**


### PR DESCRIPTION
## Summary
- track per-fish angle derived from velocity
- rotate and flip fish sprites based on movement direction

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d974ba0a4832b9c3c2edbf06aaef8