### PR TITLE
Add Zombiefish audio cues

### DIFF
--- a/src/games/zombiefish/hooks/useGameAudio.ts
+++ b/src/games/zombiefish/hooks/useGameAudio.ts
@@ -21,8 +21,11 @@ export function useGameAudio(): AudioMgr {
     const bonus = document.createElement("audio");
     bonus.src = "/audio/powerUp8.ogg"; // special-fish bonus
     bonus.preload = "auto";
+    const skeleton = document.createElement("audio");
+    skeleton.src = "/audio/splash.ogg";
+    skeleton.preload = "auto";
 
-    return { shoot, hit, bonus };
+    return { shoot, hit, bonus, skeleton };
   }, []);
 
   // Play a sound by key


### PR DESCRIPTION
## Summary
- add skeleton effect to Zombiefish audio manager
- trigger shoot/bonus/skeleton sounds and pause audio on reset

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d973cb690832baba510b4730dde7d