### PR TITLE
refactor zombiefish constants

### DIFF
--- a/src/games/zombiefish/constants.ts
+++ b/src/games/zombiefish/constants.ts
@@ -1,61 +1,19 @@
-import { PowerupType } from "@/types/objects";
-import { BASE_PATH } from "@/utils/basePath";
+/**
+ * Game-wide constants for the Zombiefish game.
+ */
 
-// ─── DEBUG FLAGS ─────────────────────────────────────────────────────────
-export const DEBUG_PLAYER_CRASH = false; // when true, player never actually “dies”
-export const TEST_SLOW_FALL = false;
-export const POWERUP_DEBUG = [] as PowerupType[]; // force a specific powerup type, or leave empty for random
+// Spawn interval for fish in frames (assuming 60 FPS).
+export const FISH_SPAWN_INTERVAL_MIN = 60; // 1 second
+export const FISH_SPAWN_INTERVAL_MAX = 180; // up to 3 seconds
 
-export const ENABLE_AUTO_FLAP = true; // auto‐flap toggle: when true, player will flap randomly
-export const AUTO_FLAP_PROB = 0.025;
+// Horizontal speed range for fish in pixels per frame.
+export const FISH_SPEED_MIN = 1;
+export const FISH_SPEED_MAX = 3;
 
-// Constants
-export const FLAP_STRENGTH = -8;
-export const PLANE_OFFSET_X = 100;
-export const MAX_AMMO = 12;
+// Speed at which skeleton fish chase others.
+export const SKELETON_SPEED = 2;
 
-export const GROUND_SPEED = 2;
-export const SMOKE_TRAIL_COUNT = 5;
-export const SKY_COLOR = "#1E90FF"; // ocean backdrop
-export const CLICK_RADIUS_MULTIPLIER = 2;
+// Time adjustments when hitting special fish (in seconds).
+export const TIME_BONUS_BROWN_FISH = 3;
+export const TIME_PENALTY_GREY_LONG = 5;
 
-export const INITIAL_ENEMY_DENSITY = 0.01; // easier start
-export const ENEMY_DENSITY_STEP = 0.005;
-export const ENEMY_SPEED = 5; // horizontal speed of enemy planes
-export const ENEMY_FLAP_INTERVAL = 60; // frames between auto-flaps
-export const ENEMY_FLAP_BASE = 8; // base flap strength
-export const ENEMY_FLAP_RANDOM = 4; // plus up to this extra
-export const ENEMY_CAN_FLAP = false; // whether enemies can flap
-export const ENEMY_GLIDE_PROB = 0.3; // chance an enemy is a glider (constant altitude)
-
-// loop-de-loop config for gliders
-export const ENEMY_LOOP_PROB = 0.001; // per-frame chance to start a loop
-export const ENEMY_LOOP_DURATION = 180; // frames to complete 1 loop
-export const ENEMY_LOOP_RADIUS = 100; // vertical radius of loop
-
-// non-loop glide altitude steps
-export const ENEMY_STEP_PROB = 0.005; // per-frame chance to start a small altitude shift
-export const ENEMY_STEP_DURATION = 60; // frames over which to perform the shift
-export const ENEMY_MAX_STEP = 150; // max vertical shift for a step
-
-// how often a dropped medal appears when you shoot an enemy
-export const ENEMY_MEDAL_SPAWN_PROB = 0.3;
-
-// point value of shooting a medal
-export const MEDAL_SCORE = 500;
-// size at which we'll draw each medal
-export const MEDAL_SIZE = 64;
-
-// ─── SCORE CONFIG ─────────────────────────────────────────────────────────
-export const SCORE_FLAP = 50;
-export const SCORE_HIT = 100;
-export const SCORE_RELOAD = 25;
-export const SCORE_DUCK = 1000;
-
-export const MIN_STREAK = 3; // minimum streak to show label
-
-// Cursor styles
-export const DEFAULT_CURSOR =
-  `url('${BASE_PATH}/assets/shooting-gallery/PNG/HUD/crosshair_red_small.png') 16 16, auto`;
-export const SHOT_CURSOR =
-  `url('${BASE_PATH}/assets/shooting-gallery/PNG/Objects/shot_brown_large.png') 16 16, auto`;

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -4,6 +4,13 @@ import { useGameAssets } from "./useGameAssets";
 import { useGameAudio } from "./useGameAudio";
 import { drawTextLabels, newTextLabel } from "@/utils/ui";
 import type { GameState, GameUIState, Fish } from "../types";
+import {
+  FISH_SPEED_MIN,
+  FISH_SPEED_MAX,
+  SKELETON_SPEED,
+  TIME_BONUS_BROWN_FISH,
+  TIME_PENALTY_GREY_LONG,
+} from "../constants";
 import type { AssetMgr } from "@/types/ui";
 import type { TextLabel } from "@/types/ui";
 import type { AudioMgr } from "@/types/audio";
@@ -15,7 +22,6 @@ const GAME_TIME = 99;
 const FPS = 60; // assumed frame rate for requestAnimationFrame
 
 const FISH_SIZE = 128;
-const SKELETON_SPEED = 2;
 const SKELETON_CONVERT_DISTANCE = FISH_SIZE / 2;
 
 export default function useGameEngine() {
@@ -456,13 +462,16 @@ export default function useGameEngine() {
         ) {
           cur.hits += 1;
           if (f.kind === "brown") {
-            cur.timer += 3 * 60;
-            makeText("+3", f.x, f.y);
+            cur.timer += TIME_BONUS_BROWN_FISH * FPS;
+            makeText(`+${TIME_BONUS_BROWN_FISH}`, f.x, f.y);
             cur.fish.splice(i, 1);
             audio.play("bonus");
           } else if (f.kind === "grey_long_a" || f.kind === "grey_long_b") {
-            cur.timer = Math.max(0, cur.timer - 5 * 60);
-            makeText("-5", f.x, f.y);
+            cur.timer = Math.max(
+              0,
+              cur.timer - TIME_PENALTY_GREY_LONG * FPS
+            );
+            makeText(`-${TIME_PENALTY_GREY_LONG}`, f.x, f.y);
             const gid = f.groupId;
             cur.fish = cur.fish.filter((fish) => fish.groupId !== gid);
             audio.play("hit");
@@ -510,7 +519,9 @@ export default function useGameEngine() {
 
     // decide side and velocity
     const fromLeft = Math.random() < 0.5;
-    const baseVx = (Math.random() * 2 + 1) * (fromLeft ? 1 : -1);
+    const speed =
+      Math.random() * (FISH_SPEED_MAX - FISH_SPEED_MIN) + FISH_SPEED_MIN;
+    const baseVx = speed * (fromLeft ? 1 : -1);
     const startX = fromLeft ? -FISH_SIZE : width + FISH_SIZE;
 
     // helper to create a fish


### PR DESCRIPTION
## Summary
- replace warbird constants with fish-specific values: spawn timing, speed ranges, skeleton speed and timer bonuses
- use new constants in game engine for fish velocity, skeleton pursuit and special-fish time adjustments

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install jest-environment-jsdom --no-save` *(fails: 403 Forbidden)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d9f600fe0832ba1c3936eda0a8d34