### PR TITLE
feat: add bubble background system

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -3,7 +3,7 @@ import { useWindowSize } from "@/hooks/useWindowSize";
 import { useGameAssets } from "./useGameAssets";
 import { useGameAudio } from "./useGameAudio";
 import { drawTextLabels, newTextLabel } from "@/utils/ui";
-import type { GameState, GameUIState, Fish } from "../types";
+import type { GameState, GameUIState, Fish, Bubble } from "../types";
 import type { AssetMgr } from "@/types/ui";
 import type { TextLabel } from "@/types/ui";
 import type { AudioMgr } from "@/types/audio";
@@ -17,6 +17,7 @@ const FPS = 60; // assumed frame rate for requestAnimationFrame
 const FISH_SIZE = 128;
 const SKELETON_SPEED = 2;
 const SKELETON_CONVERT_DISTANCE = FISH_SIZE / 2;
+const BUBBLE_SIZE = 64;
 
 export default function useGameEngine() {
   // canvas and animation frame refs
@@ -40,11 +41,14 @@ export default function useGameEngine() {
     accuracy: 0,
     dims,
     fish: [],
+    bubbles: [],
     textLabels: [],
   });
 
   const nextFishId = useRef(1);
   const nextGroupId = useRef(1);
+  const nextBubbleId = useRef(1);
+  const bubbleSpawnRef = useRef(0);
   const frameRef = useRef(0); // track frames for one-second ticks
   const accuracyLabel = useRef<TextLabel | null>(null);
   const finalAccuracy = useRef(0);
@@ -148,6 +152,26 @@ export default function useGameEngine() {
     });
   }, [audio]);
 
+  const spawnBubble = useCallback(() => {
+    const { width, height } = state.current.dims;
+    const kinds = ["bubble_a", "bubble_b", "bubble_c"];
+    const kind = kinds[Math.floor(Math.random() * kinds.length)];
+    const size = BUBBLE_SIZE * (Math.random() * 0.5 + 0.5);
+    const x = Math.random() * (width - size);
+    const y = height + size;
+    const vx = (Math.random() - 0.5) * 0.5;
+    const vy = -(Math.random() * 1 + 0.5);
+    state.current.bubbles.push({
+      id: nextBubbleId.current++,
+      kind,
+      x,
+      y,
+      vx,
+      vy,
+      size,
+    } as Bubble);
+  }, []);
+
   // main loop updates timer and fish
   const loop = useCallback(() => {
     const cur = state.current;
@@ -165,6 +189,18 @@ export default function useGameEngine() {
 
     if (cur.phase === "playing") {
       updateFish();
+
+      // spawn and animate bubbles
+      bubbleSpawnRef.current -= 1;
+      if (bubbleSpawnRef.current <= 0) {
+        spawnBubble();
+        bubbleSpawnRef.current = Math.floor(Math.random() * 60) + 30;
+      }
+      cur.bubbles.forEach((b) => {
+        b.x += b.vx;
+        b.y += b.vy;
+      });
+      cur.bubbles = cur.bubbles.filter((b) => b.y + b.size > 0);
 
       // track frames and decrement the timer once per second
       frameRef.current += 1;
@@ -288,11 +324,18 @@ export default function useGameEngine() {
         f.y < height + margin
     );
 
-    // draw fish and text labels
+    // draw bubbles, fish and text labels
     if (canvas && ctx) {
       canvas.width = cur.dims.width;
       canvas.height = cur.dims.height;
       ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      const bubbleImgs = getImg("bubbleImgs") as Record<string, HTMLImageElement>;
+      cur.bubbles.forEach((b) => {
+        const img = bubbleImgs[b.kind as keyof typeof bubbleImgs];
+        if (!img) return;
+        ctx.drawImage(img, b.x, b.y, b.size, b.size);
+      });
 
       cur.fish.forEach((f) => {
         const imgMap = getImg(
@@ -332,7 +375,7 @@ export default function useGameEngine() {
     });
 
     animationFrameRef.current = requestAnimationFrame(loop);
-  }, [updateFish, getImg, assetMgr]);
+  }, [updateFish, getImg, assetMgr, spawnBubble]);
 
   // start the game
   const startSplash = useCallback(() => {
@@ -342,11 +385,13 @@ export default function useGameEngine() {
     cur.shots = 0;
     cur.hits = 0;
     cur.accuracy = 0;
+    cur.bubbles = [];
 
     frameRef.current = 0;
     accuracyLabel.current = null;
     finalAccuracy.current = 0;
     displayAccuracy.current = 0;
+    bubbleSpawnRef.current = 0;
     state.current.textLabels = [
       newTextLabel(
         {
@@ -382,11 +427,13 @@ export default function useGameEngine() {
     cur.hits = 0;
     cur.accuracy = 0;
     cur.fish = [];
+    cur.bubbles = [];
 
     accuracyLabel.current = null;
     finalAccuracy.current = 0;
     displayAccuracy.current = 0;
     frameRef.current = 0;
+    bubbleSpawnRef.current = 0;
 
     setUI({
       phase: cur.phase,

--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -24,6 +24,19 @@ export interface Fish {
   isSkeleton?: boolean;
 }
 
+// Rising bubble drifting upward in the background
+export interface Bubble {
+  id: number;
+  /** Which bubble sprite to draw */
+  kind: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  /** Rendered size in pixels */
+  size: number;
+}
+
 // State exposed to the UI layer
 export interface GameUIState {
   phase: GamePhase;
@@ -42,6 +55,8 @@ export interface GameState extends GameUIState {
   dims: Dims;
   /** Active fish currently in the scene */
   fish: Fish[];
+  /** Bubbles floating up behind the fish */
+  bubbles: Bubble[];
   /** Floating text labels currently displayed */
   textLabels: TextLabel[];
 }


### PR DESCRIPTION
## Summary
- add rising bubble support and state to zombiefish engine
- spawn and animate bubbles, drawing them behind fish

## Testing
- `npm run lint`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found; installation of jest-environment-jsdom forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d9fea1480832bbb06c5dd4bc735a1