### PR TITLE
Adjust Zombiefish skeleton health handling

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -466,16 +466,16 @@ export default function useGameEngine() {
             const gid = f.groupId;
             cur.fish = cur.fish.filter((fish) => fish.groupId !== gid);
             audio.play("hit");
-          } else if (f.isSkeleton) {
+          } else {
+            if (!f.isSkeleton) {
+              f.isSkeleton = true;
+              f.health = 2;
+            }
             f.health = (f.health ?? 0) - 1;
             audio.play("skeleton");
             if ((f.health ?? 0) <= 0) {
               cur.fish.splice(i, 1);
             }
-          } else {
-            f.isSkeleton = true;
-            f.health = 1;
-            audio.play("skeleton");
           }
           break;
         }


### PR DESCRIPTION
## Summary
- give converted skeleton fish 2 health points
- decrement skeleton health on every click and remove when exhausted

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install --no-save jest-environment-jsdom` *(fails: 403 Forbidden)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688da036a85c832b905269fdd1e6972e