### PR TITLE
feat(zombiefish): add school offsets

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -553,8 +553,25 @@ export default function useGameEngine() {
       const groupId = specialSingles.includes(kind)
         ? undefined
         : nextGroupId.current++;
-      for (let i = 0; i < count; i++) {
-        spawned.push(makeFish(kind, 0, groupId));
+
+      if (groupId === undefined) {
+        for (let i = 0; i < count; i++) {
+          spawned.push(makeFish(kind, 0, groupId));
+        }
+      } else {
+        const leader = makeFish(kind, 0, groupId);
+        spawned.push(leader);
+        for (let i = 1; i < count; i++) {
+          const member = makeFish(kind, 0, groupId);
+          member.x = leader.x + (Math.random() - 0.5) * FISH_SIZE;
+          member.y = Math.min(
+            Math.max(leader.y + (Math.random() - 0.5) * FISH_SIZE, 0),
+            height
+          );
+          member.vx = leader.vx + (Math.random() - 0.5) * 0.5;
+          member.vy = (Math.random() - 0.5) * 0.5;
+          spawned.push(member);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- offset school members' start positions and velocities from their leader

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install jest-environment-jsdom --no-save` *(fails: 403 Forbidden)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688da03f94b4832ba54e239cd5aa7fe6