### PR TITLE
Render HUD with canvas labels

### DIFF
--- a/src/games/zombiefish/components/GameUI.tsx
+++ b/src/games/zombiefish/components/GameUI.tsx
@@ -1,32 +1,18 @@
 import React from "react";
 import Box from "@mui/material/Box";
-import { GameUIState } from "../types";
 
 export interface GameUIProps {
-  ui: GameUIState;
   canvasRef: React.RefObject<HTMLCanvasElement | null>;
   handleClick: (e: React.MouseEvent) => void;
   handleContext: (e: React.MouseEvent) => void;
-  getImg: (
-    key: string
-  ) =>
-    | HTMLImageElement
-    | HTMLImageElement[]
-    | HTMLImageElement[][]
-    | Record<string, HTMLImageElement>
-    | Record<string, HTMLImageElement[]>
-    | undefined;
 }
 
-// Minimal in-game UI showing timer, shots and hits
+// Minimal in-game UI
 export function GameUI({
-  ui,
   canvasRef,
   handleClick,
   handleContext,
 }: GameUIProps) {
-  const { timer, shots, hits } = ui;
-
   return (
     <Box position="relative" width="100vw" height="100dvh">
       <canvas
@@ -35,19 +21,6 @@ export function GameUI({
         onContextMenu={handleContext}
         style={{ display: "block", width: "100%", height: "100%" }}
       />
-
-      {/* Heads-up display */}
-      <Box
-        position="absolute"
-        top={16}
-        left={16}
-        sx={{ color: "white", fontSize: 24 }}
-      >
-        <div>Time: {timer}</div>
-        <div>Shots: {shots}</div>
-        <div>Hits: {hits}</div>
-      </Box>
-
     </Box>
   );
 }

--- a/src/games/zombiefish/index.tsx
+++ b/src/games/zombiefish/index.tsx
@@ -15,7 +15,6 @@ export default function Game() {
     canvasRef,
     handleClick,
     handleContext,
-    getImg,
     startSplash,
     ready: assetsReady,
   } = engine;
@@ -53,11 +52,9 @@ export default function Game() {
 
   return (
     <GameUI
-      ui={ui}
       canvasRef={canvasRef}
       handleClick={handleClick}
       handleContext={handleContext}
-      getImg={getImg}
     />
   );
 }


### PR DESCRIPTION
## Summary
- remove HTML counters from Zombiefish GameUI and rely solely on canvas
- manage timer, shot, and hit TextLabel instances within the engine using digit assets

## Testing
- `npm run lint`
- `npm test` *(fails: jest-environment-jsdom missing and installation attempt returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_688da0610c4c832b8b47bf45a3b1f2e4