### PR TITLE
Use isSkeleton flag in zombiefish behavior

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -103,13 +103,13 @@ export default function useGameEngine() {
 
     // skeleton behavior
     cur.fish.forEach((s) => {
-      if (s.kind !== "skeleton") return;
+      if (!s.isSkeleton) return;
 
       let nearest: Fish | undefined;
       let nearestDist = Infinity;
 
       cur.fish.forEach((t) => {
-        if (t.kind === "skeleton") return;
+        if (!t.isSkeleton) return;
         const dx = t.x - s.x;
         const dy = t.y - s.y;
         const dist2 = dx * dx + dy * dy;
@@ -129,6 +129,7 @@ export default function useGameEngine() {
         }
         if (dist < SKELETON_CONVERT_DISTANCE) {
           nearest.kind = "skeleton";
+          nearest.isSkeleton = true;
           nearest.health = 2;
           nearest.vx = 0;
           nearest.vy = 0;


### PR DESCRIPTION
## Summary
- use `isSkeleton` flag to determine when skeleton fish target others
- update conversion logic to mark targets as skeletons

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688da06a236c832bbfe51e234124ddfb