### PR TITLE
feat: keep skeletons on playfield

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -136,6 +136,13 @@ export default function useGameEngine() {
           audio.play("skeleton");
         }
       }
+
+      // steer skeletons back onto the playfield if they hit an edge
+      const { width, height } = cur.dims;
+      if (s.x < 0) s.vx = Math.abs(s.vx) || SKELETON_SPEED;
+      else if (s.x + FISH_SIZE > width) s.vx = -Math.abs(s.vx) || -SKELETON_SPEED;
+      if (s.y < 0) s.vy = Math.abs(s.vy) || SKELETON_SPEED;
+      else if (s.y + FISH_SIZE > height) s.vy = -Math.abs(s.vy) || -SKELETON_SPEED;
     });
 
     // move fish with a slight oscillation and update their angle


### PR DESCRIPTION
## Summary
- steer skeletons away from canvas edges to prevent them from leaving the playfield

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688da08480f8832b843dba28d5f578d7