### PR TITLE
feat: add cursor feedback to zombiefish

### DIFF
--- a/src/games/zombiefish/components/GameUI.tsx
+++ b/src/games/zombiefish/components/GameUI.tsx
@@ -25,7 +25,7 @@ export function GameUI({
   handleClick,
   handleContext,
 }: GameUIProps) {
-  const { timer, shots, hits } = ui;
+  const { timer, shots, hits, cursor } = ui;
 
   return (
     <Box position="relative" width="100vw" height="100dvh">
@@ -33,7 +33,7 @@ export function GameUI({
         ref={canvasRef}
         onClick={handleClick}
         onContextMenu={handleContext}
-        style={{ display: "block", width: "100%", height: "100%" }}
+        style={{ display: "block", width: "100%", height: "100%", cursor }}
       />
 
       {/* Heads-up display */}

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -3,6 +3,7 @@ import { useWindowSize } from "@/hooks/useWindowSize";
 import { useGameAssets } from "./useGameAssets";
 import { useGameAudio } from "./useGameAudio";
 import { drawTextLabels, newTextLabel } from "@/utils/ui";
+import { DEFAULT_CURSOR, SHOT_CURSOR } from "../constants";
 import type { GameState, GameUIState, Fish } from "../types";
 import type { AssetMgr } from "@/types/ui";
 import type { TextLabel } from "@/types/ui";
@@ -38,6 +39,7 @@ export default function useGameEngine() {
     shots: 0,
     hits: 0,
     accuracy: 0,
+    cursor: DEFAULT_CURSOR,
     dims,
     fish: [],
     textLabels: [],
@@ -57,6 +59,7 @@ export default function useGameEngine() {
     shots: 0,
     hits: 0,
     accuracy: 0,
+    cursor: DEFAULT_CURSOR,
   });
 
   // sync dims when window size changes
@@ -329,6 +332,7 @@ export default function useGameEngine() {
       shots: cur.shots,
       hits: cur.hits,
       accuracy: cur.accuracy,
+      cursor: cur.cursor,
     });
 
     animationFrameRef.current = requestAnimationFrame(loop);
@@ -360,12 +364,14 @@ export default function useGameEngine() {
         assetMgr
       ),
     ];
+    cur.cursor = DEFAULT_CURSOR;
     setUI({
       phase: cur.phase,
       timer: cur.timer,
       shots: cur.shots,
       hits: cur.hits,
       accuracy: cur.accuracy,
+      cursor: cur.cursor,
     });
 
     if (animationFrameRef.current)
@@ -382,6 +388,7 @@ export default function useGameEngine() {
     cur.hits = 0;
     cur.accuracy = 0;
     cur.fish = [];
+    cur.cursor = DEFAULT_CURSOR;
 
     accuracyLabel.current = null;
     finalAccuracy.current = 0;
@@ -394,6 +401,7 @@ export default function useGameEngine() {
       shots: cur.shots,
       hits: cur.hits,
       accuracy: cur.accuracy,
+      cursor: cur.cursor,
     });
     if (animationFrameRef.current)
       cancelAnimationFrame(animationFrameRef.current);
@@ -427,6 +435,19 @@ export default function useGameEngine() {
 
       if (cur.phase !== "playing") return;
 
+      cur.cursor = SHOT_CURSOR;
+      setTimeout(() => {
+        state.current.cursor = DEFAULT_CURSOR;
+        setUI({
+          phase: state.current.phase,
+          timer: state.current.timer,
+          shots: state.current.shots,
+          hits: state.current.hits,
+          accuracy: state.current.accuracy,
+          cursor: state.current.cursor,
+        });
+      }, 100);
+
       cur.shots += 1;
       audio.play("shoot");
       const canvas = canvasRef.current;
@@ -438,6 +459,7 @@ export default function useGameEngine() {
           shots: cur.shots,
           hits: cur.hits,
           accuracy: cur.accuracy,
+          cursor: cur.cursor,
         });
         return;
       }
@@ -488,6 +510,7 @@ export default function useGameEngine() {
         shots: cur.shots,
         hits: cur.hits,
         accuracy: cur.accuracy,
+        cursor: cur.cursor,
       });
     },
     [audio, makeText]

--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -35,6 +35,8 @@ export interface GameUIState {
   hits: number;
   /** Hit accuracy percentage */
   accuracy: number;
+  /** Current cursor style */
+  cursor: string;
 }
 
 // Internal game state tracked by the engine


### PR DESCRIPTION
## Summary
- track cursor style in zombiefish UI state
- flash shot cursor on clicks before reverting to default
- apply cursor style to zombiefish game canvas

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688da0bc7b7c832b8bcea7d0f93e4412