### PR TITLE
Add cursor and sky color constants for Zombiefish

### DIFF
--- a/src/games/zombiefish/constants.ts
+++ b/src/games/zombiefish/constants.ts
@@ -1,6 +1,17 @@
+import { BASE_PATH } from "@/utils/basePath";
+
 /**
  * Game-wide constants for the Zombiefish game.
  */
+
+// Cursor styles
+export const DEFAULT_CURSOR =
+  `url('${BASE_PATH}/assets/shooting-gallery/PNG/HUD/crosshair_blue_small.png') 16 16, auto`;
+export const SHOT_CURSOR =
+  `url('${BASE_PATH}/assets/shooting-gallery/PNG/HUD/crosshair_white_small.png') 16 16, auto`;
+
+// Background color representing the underwater environment
+export const SKY_COLOR = "#1d8fde";
 
 // Spawn interval for fish in frames (assuming 60 FPS).
 export const FISH_SPAWN_INTERVAL_MIN = 60; // 1 second

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -6,12 +6,10 @@ import { drawTextLabels, newTextLabel } from "@/utils/ui";
 
 import type { GameState, GameUIState, Fish, Bubble } from "../types";
 import {
-  FISH_SPEED_MIN,
-  FISH_SPEED_MAX,
   SKELETON_SPEED,
   TIME_BONUS_BROWN_FISH,
   TIME_PENALTY_GREY_LONG,
-  DEFAULT_CURSOR, 
+  DEFAULT_CURSOR,
   SHOT_CURSOR
 } from "../constants";
 import type { AssetMgr } from "@/types/ui";


### PR DESCRIPTION
## Summary
- add default and shot cursor definitions for Zombiefish
- expose underwater SKY_COLOR constant and tidy unused imports

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688da859990c832bb9c2fc7c47a76b86