### PR TITLE
Fix timer adjustments for special fish

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -6,12 +6,10 @@ import { drawTextLabels, newTextLabel } from "@/utils/ui";
 
 import type { GameState, GameUIState, Fish, Bubble } from "../types";
 import {
-  FISH_SPEED_MIN,
-  FISH_SPEED_MAX,
   SKELETON_SPEED,
   TIME_BONUS_BROWN_FISH,
   TIME_PENALTY_GREY_LONG,
-  DEFAULT_CURSOR, 
+  DEFAULT_CURSOR,
   SHOT_CURSOR
 } from "../constants";
 import type { AssetMgr } from "@/types/ui";
@@ -654,15 +652,17 @@ export default function useGameEngine() {
           cur.hits += 1;
           updateDigitLabel(hitsLabel.current, cur.hits);
           if (f.kind === "brown") {
-            cur.timer += TIME_BONUS_BROWN_FISH * FPS;
+            cur.timer += TIME_BONUS_BROWN_FISH;
+            updateDigitLabel(timerLabel.current, cur.timer, 2);
             makeText(`+${TIME_BONUS_BROWN_FISH}`, f.x, f.y);
             cur.fish.splice(i, 1);
             audio.play("bonus");
           } else if (f.kind === "grey_long_a" || f.kind === "grey_long_b") {
             cur.timer = Math.max(
               0,
-              cur.timer - TIME_PENALTY_GREY_LONG * FPS
+              cur.timer - TIME_PENALTY_GREY_LONG
             );
+            updateDigitLabel(timerLabel.current, cur.timer, 2);
             makeText(`-${TIME_PENALTY_GREY_LONG}`, f.x, f.y);
             const gid = f.groupId;
             cur.fish = cur.fish.filter((fish) => fish.groupId !== gid);


### PR DESCRIPTION
## Summary
- remove frame-based scaling for brown/grey-long fish timers and update timer label
- drop unused speed constants

## Testing
- `npm run lint`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688da87c9f3c832b9e513fe45fe77d8f