### PR TITLE
Ensure group ID is applied to spawned fish members

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -817,7 +817,7 @@ export default function useGameEngine() {
         const leader = makeFish(kind, x, y, groupId);
         spawned.push(leader);
         for (let i = 1; i < count; i++) {
-          const member = makeFish(kind, 0, groupId);
+          const member = makeFish(kind, leader.x, leader.y, groupId);
           member.x = leader.x + (Math.random() - 0.5) * FISH_SIZE;
           member.y = Math.min(
             Math.max(leader.y + (Math.random() - 0.5) * FISH_SIZE, 0),


### PR DESCRIPTION
## Summary
- fix group spawn logic so fish members are created with leader coordinates and shared groupId

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*


------
https://chatgpt.com/codex/tasks/task_e_688da88e6f34832bb31fe5ee3073d7ec