### PR TITLE
Use constants for fish spawn interval

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -6,12 +6,12 @@ import { drawTextLabels, newTextLabel } from "@/utils/ui";
 
 import type { GameState, GameUIState, Fish, Bubble } from "../types";
 import {
-  FISH_SPEED_MIN,
-  FISH_SPEED_MAX,
+  FISH_SPAWN_INTERVAL_MIN,
+  FISH_SPAWN_INTERVAL_MAX,
   SKELETON_SPEED,
   TIME_BONUS_BROWN_FISH,
   TIME_PENALTY_GREY_LONG,
-  DEFAULT_CURSOR, 
+  DEFAULT_CURSOR,
   SHOT_CURSOR
 } from "../constants";
 import type { AssetMgr } from "@/types/ui";
@@ -840,7 +840,9 @@ export default function useGameEngine() {
     const basicKinds = ["blue", "green", "grey", "orange", "pink", "red"];
     let timer: ReturnType<typeof setTimeout>;
     const schedule = () => {
-      const delay = 1000 + Math.random() * 2000;
+      const minDelay = (FISH_SPAWN_INTERVAL_MIN / FPS) * 1000;
+      const maxDelay = (FISH_SPAWN_INTERVAL_MAX / FPS) * 1000;
+      const delay = minDelay + Math.random() * (maxDelay - minDelay);
       timer = setTimeout(() => {
         if (state.current.phase !== "playing") return;
         const kind = basicKinds[Math.floor(Math.random() * basicKinds.length)];


### PR DESCRIPTION
## Summary
- compute spawn scheduler delay using FISH_SPAWN_INTERVAL_MIN/MAX constants
- remove unused speed constants

## Testing
- `npm run lint`
- `npm test` (fails: Test environment jest-environment-jsdom cannot be found; installing jest-environment-jsdom fails with 403)


------
https://chatgpt.com/codex/tasks/task_e_688da894a990832bbdc950098ef28728