### PR TITLE
Use withBasePath for Zombie Fish audio

### DIFF
--- a/src/games/zombiefish/hooks/useGameAudio.ts
+++ b/src/games/zombiefish/hooks/useGameAudio.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { AudioMgr } from "@/types/audio";
+import { withBasePath } from "@/utils/basePath";
 
 /**
  * Simple audio manager for Zombie Fish.
@@ -12,22 +13,22 @@ export function useGameAudio(): AudioMgr {
       return {} as Record<string, HTMLAudioElement>;
 
     const shoot = document.createElement("audio");
-    shoot.src = "/audio/laser4.ogg";
+    shoot.src = withBasePath("/audio/laser4.ogg");
     shoot.preload = "auto";
 
     const hit = document.createElement("audio");
-    hit.src = "/audio/laser9.ogg";
+    hit.src = withBasePath("/audio/laser9.ogg");
     hit.preload = "auto";
 
     const bonus = document.createElement("audio");
-    bonus.src = "/audio/powerUp8.ogg"; // special-fish bonus
+    bonus.src = withBasePath("/audio/powerUp8.ogg"); // special-fish bonus
     bonus.preload = "auto";
     const skeleton = document.createElement("audio");
-    skeleton.src = "/audio/splash.ogg";
+    skeleton.src = withBasePath("/audio/splash.ogg");
     skeleton.preload = "auto";
 
     const convert = document.createElement("audio");
-    convert.src = "/audio/zap1.ogg";
+    convert.src = withBasePath("/audio/zap1.ogg");
     convert.preload = "auto";
 
     return { shoot, hit, bonus, skeleton, convert };

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -6,13 +6,11 @@ import { drawTextLabels, newTextLabel } from "@/utils/ui";
 
 import type { GameState, GameUIState, Fish, Bubble } from "../types";
 import {
-  FISH_SPEED_MIN,
-  FISH_SPEED_MAX,
   SKELETON_SPEED,
   TIME_BONUS_BROWN_FISH,
   TIME_PENALTY_GREY_LONG,
-  DEFAULT_CURSOR, 
-  SHOT_CURSOR
+  DEFAULT_CURSOR,
+  SHOT_CURSOR,
 } from "../constants";
 import type { AssetMgr } from "@/types/ui";
 import type { TextLabel } from "@/types/ui";


### PR DESCRIPTION
## Summary
- wrap Zombie Fish audio sources with `withBasePath`
- remove unused speed constants from Zombie Fish game engine

## Testing
- `npm run lint`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688da8abc1a0832b8cebb601e246455a