### PR TITLE
feat: preload cursor assets

### DIFF
--- a/src/games/straightcash/constants.ts
+++ b/src/games/straightcash/constants.ts
@@ -1,5 +1,2 @@
-import { BASE_PATH } from "@/utils/basePath";
-
 export const SKY_COLOR = "#6CA6CD";
-export const DEFAULT_CURSOR = `url('${BASE_PATH}/assets/shooting-gallery/PNG/HUD/crosshair_red_small.png') 16 16, auto`;
-export const SHOT_CURSOR = `url('${BASE_PATH}/assets/shooting-gallery/PNG/Objects/shot_brown_large.png') 16 16, auto`;
+export { DEFAULT_CURSOR, SHOT_CURSOR } from "../warbirds/constants";

--- a/src/games/warbirds/constants.ts
+++ b/src/games/warbirds/constants.ts
@@ -55,7 +55,12 @@ export const SCORE_DUCK = 1000;
 export const MIN_STREAK = 3; // minimum streak to show label
 
 // Cursor styles
-export const DEFAULT_CURSOR =
+export let DEFAULT_CURSOR =
   `url('${BASE_PATH}/assets/shooting-gallery/PNG/HUD/crosshair_red_small.png') 16 16, auto`;
-export const SHOT_CURSOR =
+export let SHOT_CURSOR =
   `url('${BASE_PATH}/assets/shooting-gallery/PNG/Objects/shot_brown_large.png') 16 16, auto`;
+
+export const setCursorImgs = (cursorSrc: string, shotSrc: string) => {
+  DEFAULT_CURSOR = `url('${cursorSrc}') 16 16, auto`;
+  SHOT_CURSOR = `url('${shotSrc}') 16 16, auto`;
+};

--- a/src/games/warbirds/hooks/useGameAssets.ts
+++ b/src/games/warbirds/hooks/useGameAssets.ts
@@ -23,6 +23,10 @@ import { SCORE_DIGIT_PATH } from "@/constants/ui";
 import { ENEMY_COLORS, AIRSHIP_COLORS } from "@/constants/vehicles";
 import { AssetMgr } from "@/types/ui";
 import { withBasePath } from "@/utils/basePath";
+import { setCursorImgs } from "../constants";
+
+export let cursorImg: HTMLImageElement | undefined;
+export let shotCursorImg: HTMLImageElement | undefined;
 
 /**
  * SSR-safe asset loader for browser games.
@@ -34,6 +38,8 @@ export function useGameAssets(): {
   getImg: AssetMgr["getImg"];
   assetRefs: AssetMgr["assetRefs"];
   ready: boolean;
+  cursorImg?: HTMLImageElement;
+  shotCursorImg?: HTMLImageElement;
 } {
   const [ready, setReady] = useState(false);
 
@@ -80,10 +86,17 @@ export function useGameAssets(): {
       "/assets/shooting-gallery/PNG/Objects/stick_wood_broken.png"
     );
 
-    // BULLET HOLE
-    assetRefs.current.bulletHoleImg = loadImg(
+    // CURSOR IMAGES
+    cursorImg = loadImg(
+      "/assets/shooting-gallery/PNG/HUD/crosshair_red_small.png"
+    );
+    shotCursorImg = loadImg(
       "/assets/shooting-gallery/PNG/Objects/shot_brown_large.png"
     );
+    assetRefs.current.cursorImg = cursorImg;
+    assetRefs.current.shotCursorImg = shotCursorImg;
+    assetRefs.current.bulletHoleImg = shotCursorImg;
+    setCursorImgs(cursorImg.src, shotCursorImg.src);
 
     // CANNONBALL
     assetRefs.current.cannonballImg = loadImg(
@@ -263,5 +276,12 @@ export function useGameAssets(): {
     []
   );
 
-  return { get, getImg, assetRefs: assetRefs.current, ready };
+  return {
+    get,
+    getImg,
+    assetRefs: assetRefs.current,
+    ready,
+    cursorImg,
+    shotCursorImg,
+  };
 }


### PR DESCRIPTION
## Summary
- preload crosshair and shot cursor images in the asset hook and surface them for consumers
- update cursor constants to use preloaded images via `setCursorImgs`
- share cursor constants with Straight Cash

## Testing
- `npm run lint` *(fails: 'FISH_SPEED_MIN' and 'FISH_SPEED_MAX' are defined but never used)*
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688da8b18988832b9080c3ccef0bba55