### PR TITLE
feat(zombiefish): add skeleton death sound

### DIFF
--- a/src/games/zombiefish/hooks/useGameAudio.ts
+++ b/src/games/zombiefish/hooks/useGameAudio.ts
@@ -26,11 +26,15 @@ export function useGameAudio(): AudioMgr {
     skeleton.src = "/audio/splash.ogg";
     skeleton.preload = "auto";
 
+    const death = document.createElement("audio");
+    death.src = "/audio/lowDown.ogg";
+    death.preload = "auto";
+
     const convert = document.createElement("audio");
     convert.src = "/audio/zap1.ogg";
     convert.preload = "auto";
 
-    return { shoot, hit, bonus, skeleton, convert };
+    return { shoot, hit, bonus, skeleton, death, convert };
   }, []);
 
   // Play a sound by key

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -6,13 +6,11 @@ import { drawTextLabels, newTextLabel } from "@/utils/ui";
 
 import type { GameState, GameUIState, Fish, Bubble } from "../types";
 import {
-  FISH_SPEED_MIN,
-  FISH_SPEED_MAX,
   SKELETON_SPEED,
   TIME_BONUS_BROWN_FISH,
   TIME_PENALTY_GREY_LONG,
-  DEFAULT_CURSOR, 
-  SHOT_CURSOR
+  DEFAULT_CURSOR,
+  SHOT_CURSOR,
 } from "../constants";
 import type { AssetMgr } from "@/types/ui";
 import type { TextLabel } from "@/types/ui";
@@ -673,9 +671,11 @@ export default function useGameEngine() {
               f.health = 2;
             }
             f.health = (f.health ?? 0) - 1;
-            audio.play("skeleton");
             if ((f.health ?? 0) <= 0) {
               cur.fish.splice(i, 1);
+              audio.play("death");
+            } else {
+              audio.play("skeleton");
             }
           }
           break;


### PR DESCRIPTION
## Summary
- add `death` audio clip for Zombie Fish
- play death sound when skeleton defeated

## Testing
- `npm run lint`
- `npm test` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_688da8b99c1c832b946fab64af3349ba