### PR TITLE
feat: reset with spacebar on game over

### DIFF
--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -3420,6 +3420,17 @@ export function useGameEngine() {
     startSplash();
   };
 
+  useEffect(() => {
+    const handleKeydown = (e: KeyboardEvent) => {
+      if (state.current.phase === "gameover" && e.code === "Space") {
+        resetGame();
+        startSplash();
+      }
+    };
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  }, [resetGame, startSplash]);
+
   // ─── CLEANUP ─────────────────────────────────────────────
   useEffect(() => {
     return () => {

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -581,6 +581,17 @@ export default function useGameEngine() {
       cancelAnimationFrame(animationFrameRef.current);
   }, []);
 
+  useEffect(() => {
+    const handleKeydown = (e: KeyboardEvent) => {
+      if (state.current.phase === "gameover" && e.code === "Space") {
+        resetGame();
+        startSplash();
+      }
+    };
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  }, [resetGame, startSplash]);
+
   // handle left click – detect and affect fish
   const handleClick = useCallback(
     (e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary
- let players restart from game over using the spacebar in both games
- clean up key listeners on unmount

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688da8c8d454832bb2931f5290d7ffe8