### PR TITLE
Ramp fish difficulty over time

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -6,12 +6,10 @@ import { drawTextLabels, newTextLabel } from "@/utils/ui";
 
 import type { GameState, GameUIState, Fish, Bubble } from "../types";
 import {
-  FISH_SPEED_MIN,
-  FISH_SPEED_MAX,
   SKELETON_SPEED,
   TIME_BONUS_BROWN_FISH,
   TIME_PENALTY_GREY_LONG,
-  DEFAULT_CURSOR, 
+  DEFAULT_CURSOR,
   SHOT_CURSOR
 } from "../constants";
 import type { AssetMgr } from "@/types/ui";
@@ -700,6 +698,9 @@ export default function useGameEngine() {
     e.preventDefault();
   }, []);
 
+  // factor that ramps up difficulty as time runs out
+  const difficultyFactor = () => 1 + (1 - state.current.timer / GAME_TIME);
+
   // spawn a group of fish just outside the viewport edges
   const spawnFish = useCallback((kind: string, count: number): Fish[] => {
     const spawned: Fish[] = [];
@@ -719,8 +720,9 @@ export default function useGameEngine() {
 
     // generate a velocity based on the entry edge
     const genVelocity = () => {
-      const main = Math.random() * 2 + 1;
-      const cross = Math.random() * 2 - 1;
+      const factor = difficultyFactor();
+      const main = (Math.random() * 2 + 1) * factor;
+      const cross = (Math.random() * 2 - 1) * factor;
       switch (edge) {
         case 0:
           return { vx: main, vy: cross };
@@ -840,7 +842,8 @@ export default function useGameEngine() {
     const basicKinds = ["blue", "green", "grey", "orange", "pink", "red"];
     let timer: ReturnType<typeof setTimeout>;
     const schedule = () => {
-      const delay = 1000 + Math.random() * 2000;
+      const factor = difficultyFactor();
+      const delay = (1000 + Math.random() * 2000) / factor;
       timer = setTimeout(() => {
         if (state.current.phase !== "playing") return;
         const kind = basicKinds[Math.floor(Math.random() * basicKinds.length)];


### PR DESCRIPTION
## Summary
- Scale difficulty as timer runs out by computing a time-based factor
- Apply factor to fish velocity generation and spawn scheduling to ramp up challenge

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688da920c4b0832b83ae68907adb8561