### PR TITLE
feat: start games on space press

### DIFF
--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -3422,8 +3422,11 @@ export function useGameEngine() {
 
   useEffect(() => {
     const handleKeydown = (e: KeyboardEvent) => {
-      if (state.current.phase === "gameover" && e.code === "Space") {
+      if (e.code !== "Space") return;
+      if (state.current.phase === "gameover") {
         resetGame();
+        startSplash();
+      } else if (state.current.phase === "title") {
         startSplash();
       }
     };

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -6,8 +6,6 @@ import { drawTextLabels, newTextLabel } from "@/utils/ui";
 
 import type { GameState, GameUIState, Fish, Bubble } from "../types";
 import {
-  FISH_SPAWN_INTERVAL_MIN,
-  FISH_SPAWN_INTERVAL_MAX,
   SKELETON_SPEED,
   TIME_BONUS_BROWN_FISH,
   TIME_PENALTY_GREY_LONG,
@@ -594,8 +592,11 @@ export default function useGameEngine() {
 
   useEffect(() => {
     const handleKeydown = (e: KeyboardEvent) => {
-      if (state.current.phase === "gameover" && e.code === "Space") {
+      if (e.code !== "Space") return;
+      if (state.current.phase === "gameover") {
         resetGame();
+        startSplash();
+      } else if (state.current.phase === "title") {
         startSplash();
       }
     };


### PR DESCRIPTION
## Summary
- start Zombie Fish when Space is pressed on title screen
- start Warbirds when Space is pressed on title screen

## Testing
- `npm run lint`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688dae935190832baec09d7c54d01417