### PR TITLE
Render HUD label letters in Zombiefish game

### DIFF
--- a/src/games/zombiefish/hooks/useGameAssets.ts
+++ b/src/games/zombiefish/hooks/useGameAssets.ts
@@ -165,8 +165,28 @@ export function useGameAssets(): {
     minusImg.src = minusCanvas.toDataURL();
     assetRefs.current.minusImg = minusImg;
 
-    // LETTER IMAGES (none provided in assets, but keep key for API parity)
+    // LETTER IMAGES
+    // Assets do not include letters, so dynamically generate them
     assetRefs.current.letterImgs = {};
+    const letterCanvas = document.createElement("canvas");
+    const baseImg = assetRefs.current.digitImgs["0"] as HTMLImageElement;
+    letterCanvas.width = baseImg?.width || 32;
+    letterCanvas.height = baseImg?.height || 32;
+    const lctx = letterCanvas.getContext("2d");
+    if (lctx) {
+      lctx.fillStyle = "white";
+      lctx.textAlign = "center";
+      lctx.textBaseline = "middle";
+      lctx.font = `${letterCanvas.height}px sans-serif`;
+      for (let c = 65; c <= 90; c++) {
+        const ch = String.fromCharCode(c);
+        lctx.clearRect(0, 0, letterCanvas.width, letterCanvas.height);
+        lctx.fillText(ch, letterCanvas.width / 2, letterCanvas.height / 2);
+        const img = new window.Image();
+        img.src = letterCanvas.toDataURL();
+        assetRefs.current.letterImgs[ch] = img;
+      }
+    }
 
     setReady(true);
   }, []);

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -6,8 +6,6 @@ import { drawTextLabels, newTextLabel } from "@/utils/ui";
 
 import type { GameState, GameUIState, Fish, Bubble } from "../types";
 import {
-  FISH_SPAWN_INTERVAL_MIN,
-  FISH_SPAWN_INTERVAL_MAX,
   SKELETON_SPEED,
   TIME_BONUS_BROWN_FISH,
   TIME_PENALTY_GREY_LONG,
@@ -503,14 +501,43 @@ export default function useGameEngine() {
     const digitHeight = digitImgs["0"]?.height || 0;
     const lineHeight = digitHeight + 8;
 
+    const labelWidth = (lbl: TextLabel) =>
+      lbl.imgs.reduce(
+        (sum, img) => sum + (img ? img.width + 2 : lbl.spaceGap),
+        0
+      );
+
+    const timeText = newTextLabel(
+      {
+        text: "TIME",
+        scale: 1,
+        fixed: true,
+        fade: false,
+        x: 16,
+        y: 16,
+      },
+      assetMgr
+    );
     timerLabel.current = newTextLabel(
       {
         text: cur.timer.toString().padStart(2, "0"),
         scale: 1,
         fixed: true,
         fade: false,
-        x: 16,
+        x: 16 + labelWidth(timeText),
         y: 16,
+      },
+      assetMgr
+    );
+
+    const shotsText = newTextLabel(
+      {
+        text: "SHOTS",
+        scale: 1,
+        fixed: true,
+        fade: false,
+        x: 16,
+        y: 16 + lineHeight,
       },
       assetMgr
     );
@@ -520,8 +547,20 @@ export default function useGameEngine() {
         scale: 1,
         fixed: true,
         fade: false,
-        x: 16,
+        x: 16 + labelWidth(shotsText),
         y: 16 + lineHeight,
+      },
+      assetMgr
+    );
+
+    const hitsText = newTextLabel(
+      {
+        text: "HITS",
+        scale: 1,
+        fixed: true,
+        fade: false,
+        x: 16,
+        y: 16 + lineHeight * 2,
       },
       assetMgr
     );
@@ -531,7 +570,7 @@ export default function useGameEngine() {
         scale: 1,
         fixed: true,
         fade: false,
-        x: 16,
+        x: 16 + labelWidth(hitsText),
         y: 16 + lineHeight * 2,
       },
       assetMgr
@@ -539,8 +578,11 @@ export default function useGameEngine() {
     bubbleSpawnRef.current = 0;
 
     state.current.textLabels = [
+      timeText,
       timerLabel.current!,
+      shotsText,
       shotsLabel.current!,
+      hitsText,
       hitsLabel.current!,
     ];
     cur.cursor = DEFAULT_CURSOR;


### PR DESCRIPTION
## Summary
- Dynamically render A-Z letter sprites via canvas in Zombiefish asset hook
- Use generated letters for HUD labels: TIME, SHOTS, HITS

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dae8f8c94832b938ad6d4f13e63e2