### PR TITLE
Add conversion effect when skeleton converts fish

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -6,8 +6,6 @@ import { drawTextLabels, newTextLabel } from "@/utils/ui";
 
 import type { GameState, GameUIState, Fish, Bubble } from "../types";
 import {
-  FISH_SPAWN_INTERVAL_MIN,
-  FISH_SPAWN_INTERVAL_MAX,
   SKELETON_SPEED,
   TIME_BONUS_BROWN_FISH,
   TIME_PENALTY_GREY_LONG,
@@ -236,6 +234,8 @@ export default function useGameEngine() {
           dist < SKELETON_CONVERT_DISTANCE &&
           !immuneKinds.has(nearest.kind)
         ) {
+          // Spawn a brief text effect before converting the fish
+          makeText("POOF", nearest.x, nearest.y);
           nearest.isSkeleton = true;
           nearest.health = 2;
           nearest.vx = 0;
@@ -261,7 +261,7 @@ export default function useGameEngine() {
       f.y += vy;
       f.angle = Math.atan2(vy, Math.abs(f.vx));
     });
-  }, [audio]);
+  }, [audio, makeText]);
 
   const spawnBubble = useCallback(() => {
     const { width, height } = state.current.dims;


### PR DESCRIPTION
## Summary
- show brief POOF text when a skeleton converts a fish
- update game engine hook to depend on the text label helper

## Testing
- `npm run lint`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688dae96b224832bb804d12ed324d1d0