### PR TITLE
feat: add title high score

### DIFF
--- a/src/games/zombiefish/components/TitleSplash.tsx
+++ b/src/games/zombiefish/components/TitleSplash.tsx
@@ -1,12 +1,15 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 
 import Box from "@mui/material/Box";
+import { drawTextLabels, newTextLabel } from "@/utils/ui";
+import type { AssetMgr } from "@/types/ui";
 
 export interface TitleSplashProps {
   onStart: () => void;
   titleSrc: string;
   backgroundColor: string;
   cursor: string;
+  getImg: AssetMgr["getImg"];
 }
 
 export const TitleSplash: React.FC<TitleSplashProps> = ({
@@ -14,22 +17,61 @@ export const TitleSplash: React.FC<TitleSplashProps> = ({
   titleSrc,
   backgroundColor,
   cursor,
-}) => (
-  <Box
-    position="relative"
-    width="100vw"
-    height="100dvh"
-    sx={{ backgroundColor, cursor }}
-    display="flex"
-    justifyContent="center"
-    alignItems="center"
-    onClick={onStart}
-  >
-  <Box
-    component="img"
-    src={titleSrc}
-    alt="Zombiefish"
-    sx={{ width: "auto", height: "100%", cursor }}
-  />
-</Box>
-);
+  getImg,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const best = Number(localStorage.bestAccuracy || 0);
+    const assetMgr = { getImg } as AssetMgr;
+    const lbl = newTextLabel(
+      {
+        text: `${best}%`,
+        scale: 1,
+        fixed: true,
+        fade: false,
+        x: 16,
+        y: 16,
+      },
+      assetMgr
+    );
+    drawTextLabels({ textLabels: [lbl], ctx });
+  }, [getImg]);
+
+  return (
+    <Box
+      position="relative"
+      width="100vw"
+      height="100dvh"
+      sx={{ backgroundColor, cursor }}
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      onClick={onStart}
+    >
+      <canvas
+        ref={canvasRef}
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: "100%",
+          height: "100%",
+          pointerEvents: "none",
+        }}
+      />
+      <Box
+        component="img"
+        src={titleSrc}
+        alt="Zombiefish"
+        sx={{ width: "auto", height: "100%", cursor }}
+      />
+    </Box>
+  );
+};

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -6,8 +6,6 @@ import { drawTextLabels, newTextLabel } from "@/utils/ui";
 
 import type { GameState, GameUIState, Fish, Bubble } from "../types";
 import {
-  FISH_SPAWN_INTERVAL_MIN,
-  FISH_SPAWN_INTERVAL_MAX,
   SKELETON_SPEED,
   TIME_BONUS_BROWN_FISH,
   TIME_PENALTY_GREY_LONG,
@@ -325,6 +323,10 @@ export default function useGameEngine() {
         if (cur.timer === 0) {
           cur.phase = "gameover";
           finalAccuracy.current = Math.round(cur.accuracy);
+          const best = Number(localStorage.bestAccuracy || 0);
+          if (finalAccuracy.current > best) {
+            localStorage.bestAccuracy = finalAccuracy.current.toString();
+          }
           displayAccuracy.current = 0;
         }
       }

--- a/src/games/zombiefish/index.tsx
+++ b/src/games/zombiefish/index.tsx
@@ -17,6 +17,7 @@ export default function Game() {
     handleContext,
     startSplash,
     ready: assetsReady,
+    getImg,
   } = engine;
 
   const [startRequested, setStartRequested] = useState(false);
@@ -46,6 +47,7 @@ export default function Game() {
         titleSrc={withBasePath("/assets/titles/zombiefish_title.png")}
         backgroundColor={SKY_COLOR}
         cursor={DEFAULT_CURSOR}
+        getImg={getImg}
       />
     );
   }


### PR DESCRIPTION
## Summary
- persist best accuracy when a round ends
- show stored best accuracy on the Zombiefish title screen

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688daeaf0440832b887a66da8b359158