### PR TITLE
Add parallax scrolling to Zombiefish background

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -6,8 +6,6 @@ import { drawTextLabels, newTextLabel } from "@/utils/ui";
 
 import type { GameState, GameUIState, Fish, Bubble } from "../types";
 import {
-  FISH_SPAWN_INTERVAL_MIN,
-  FISH_SPAWN_INTERVAL_MAX,
   SKELETON_SPEED,
   TIME_BONUS_BROWN_FISH,
   TIME_PENALTY_GREY_LONG,
@@ -27,6 +25,8 @@ const FPS = 60; // assumed frame rate for requestAnimationFrame
 const FISH_SIZE = 128;
 const SKELETON_CONVERT_DISTANCE = FISH_SIZE / 2;
 const BUBBLE_SIZE = 64;
+const ROCK_SPEED = 0.2;
+const SEAWEED_SPEED = 0.4;
 
 export default function useGameEngine() {
   // canvas and animation frame refs
@@ -60,6 +60,8 @@ export default function useGameEngine() {
   const nextBubbleId = useRef(1);
   const bubbleSpawnRef = useRef(0);
   const frameRef = useRef(0); // track frames for one-second ticks
+  const rockOffset = useRef(0);
+  const seaweedOffset = useRef(0);
   const accuracyLabel = useRef<TextLabel | null>(null);
   const finalAccuracy = useRef(0);
   const displayAccuracy = useRef(0);
@@ -97,6 +99,10 @@ export default function useGameEngine() {
   const drawBackground = useCallback(
     (ctx: CanvasRenderingContext2D) => {
       const { width, height } = state.current.dims;
+      rockOffset.current -= ROCK_SPEED;
+      seaweedOffset.current -= SEAWEED_SPEED;
+      if (rockOffset.current <= -width) rockOffset.current += width;
+      if (seaweedOffset.current <= -width) seaweedOffset.current += width;
 
       const waterImgs = getImg("terrainWaterImgs") as
         | Record<string, HTMLImageElement>
@@ -142,10 +148,17 @@ export default function useGameEngine() {
       if (rockImgs) {
         const rA = rockImgs.background_rock_a;
         const rB = rockImgs.background_rock_b;
-        // Rock positions roughly match the layout in
-        // public/assets/fish/Sample.png
-        if (rA) ctx.drawImage(rA, width * 0.1, groundY - rA.height);
-        if (rB) ctx.drawImage(rB, width * 0.7, groundY - rB.height);
+        const rocks = [
+          { img: rA, x: width * 0.1 },
+          { img: rB, x: width * 0.7 },
+        ];
+        rocks.forEach(({ img, x }) => {
+          if (!img) return;
+          const y = groundY - img.height;
+          const drawX = x + rockOffset.current;
+          ctx.drawImage(img, drawX, y);
+          ctx.drawImage(img, drawX + width, y);
+        });
       }
 
       const seaweedImgs = getImg("seaweedImgs") as
@@ -158,10 +171,12 @@ export default function useGameEngine() {
           { img: seaweedImgs.background_seaweed_c, x: width * 0.5 },
           { img: seaweedImgs.background_seaweed_e, x: width * 0.8 },
         ];
-        // Seaweed clusters are placed near the rocks as seen in
-        // public/assets/fish/Sample.png
         sw.forEach(({ img, x }) => {
-          if (img) ctx.drawImage(img, x, bottom - img.height);
+          if (!img) return;
+          const y = bottom - img.height;
+          const drawX = x + seaweedOffset.current;
+          ctx.drawImage(img, drawX, y);
+          ctx.drawImage(img, drawX + width, y);
         });
       }
     },
@@ -499,6 +514,8 @@ export default function useGameEngine() {
     accuracyLabel.current = null;
     finalAccuracy.current = 0;
     displayAccuracy.current = 0;
+    rockOffset.current = 0;
+    seaweedOffset.current = 0;
     const digitImgs = getImg("digitImgs") as Record<string, HTMLImageElement>;
     const digitHeight = digitImgs["0"]?.height || 0;
     const lineHeight = digitHeight + 8;
@@ -579,6 +596,8 @@ export default function useGameEngine() {
     hitsLabel.current = null;
     state.current.textLabels = [];
     bubbleSpawnRef.current = 0;
+    rockOffset.current = 0;
+    seaweedOffset.current = 0;
 
     setUI({
       phase: cur.phase,


### PR DESCRIPTION
## Summary
- Animate rock and seaweed layers with independent horizontal offsets for a parallax effect
- Reset background offsets when starting or restarting the game

## Testing
- `npm run lint`
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688daec1f964832ba398e0b76895b9bc