### PR TITLE
Add background music controls for Zombie Fish

### DIFF
--- a/src/games/zombiefish/hooks/useGameAudio.ts
+++ b/src/games/zombiefish/hooks/useGameAudio.ts
@@ -35,7 +35,12 @@ export function useGameAudio(): AudioMgr {
     convert.src = withBasePath("/audio/zap1.ogg");
     convert.preload = "auto";
 
-    return { shoot, hit, bonus, skeleton, death, convert };
+    const bgm = document.createElement("audio");
+    bgm.src = withBasePath("/audio/back_001.ogg");
+    bgm.preload = "auto";
+    bgm.loop = true;
+
+    return { shoot, hit, bonus, skeleton, death, convert, bgm };
   }, []);
 
   // Play a sound by key

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -6,8 +6,6 @@ import { drawTextLabels, newTextLabel } from "@/utils/ui";
 
 import type { GameState, GameUIState, Fish, Bubble } from "../types";
 import {
-  FISH_SPAWN_INTERVAL_MIN,
-  FISH_SPAWN_INTERVAL_MAX,
   SKELETON_SPEED,
   TIME_BONUS_BROWN_FISH,
   TIME_PENALTY_GREY_LONG,
@@ -326,6 +324,7 @@ export default function useGameEngine() {
           cur.phase = "gameover";
           finalAccuracy.current = Math.round(cur.accuracy);
           displayAccuracy.current = 0;
+          audio.pause("bgm");
         }
       }
 
@@ -503,6 +502,8 @@ export default function useGameEngine() {
     const digitHeight = digitImgs["0"]?.height || 0;
     const lineHeight = digitHeight + 8;
 
+    audio.play("bgm");
+
     timerLabel.current = newTextLabel(
       {
         text: cur.timer.toString().padStart(2, "0"),
@@ -590,6 +591,7 @@ export default function useGameEngine() {
     });
     if (animationFrameRef.current)
       cancelAnimationFrame(animationFrameRef.current);
+    audio.pause("bgm");
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Load looping bgm track in Zombie Fish audio manager
- Play bgm when game starts
- Pause bgm on reset and game over

## Testing
- `npm run lint`
- `npm test` *(fails: jest-environment-jsdom missing; install attempt returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_688daed3b2d8832bab0a88188523bdbe