### PR TITLE
Randomize skeleton conversion for basic zombiefish

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -6,8 +6,6 @@ import { drawTextLabels, newTextLabel } from "@/utils/ui";
 
 import type { GameState, GameUIState, Fish, Bubble } from "../types";
 import {
-  FISH_SPAWN_INTERVAL_MIN,
-  FISH_SPAWN_INTERVAL_MAX,
   SKELETON_SPEED,
   TIME_BONUS_BROWN_FISH,
   TIME_PENALTY_GREY_LONG,
@@ -693,15 +691,22 @@ export default function useGameEngine() {
             audio.play("hit");
           } else {
             if (!f.isSkeleton) {
-              f.isSkeleton = true;
-              f.health = 2;
-            }
-            f.health = (f.health ?? 0) - 1;
-            if ((f.health ?? 0) <= 0) {
-              cur.fish.splice(i, 1);
-              audio.play("death");
+              if (Math.random() < 0.5) {
+                f.isSkeleton = true;
+                f.health = 1;
+                audio.play("skeleton");
+              } else {
+                cur.fish.splice(i, 1);
+                audio.play("death");
+              }
             } else {
-              audio.play("skeleton");
+              f.health = (f.health ?? 0) - 1;
+              if ((f.health ?? 0) <= 0) {
+                cur.fish.splice(i, 1);
+                audio.play("death");
+              } else {
+                audio.play("skeleton");
+              }
             }
           }
           break;


### PR DESCRIPTION
## Summary
- add 50% chance for basic fish to turn into skeleton or die on hit
- remove unused fish spawn interval constants

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688daee01f00832bb68b48e740d0105a