### PR TITLE
feat: vary fish speed using constants

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -6,8 +6,8 @@ import { drawTextLabels, newTextLabel } from "@/utils/ui";
 
 import type { GameState, GameUIState, Fish, Bubble } from "../types";
 import {
-  FISH_SPAWN_INTERVAL_MIN,
-  FISH_SPAWN_INTERVAL_MAX,
+  FISH_SPEED_MIN,
+  FISH_SPEED_MAX,
   SKELETON_SPEED,
   TIME_BONUS_BROWN_FISH,
   TIME_PENALTY_GREY_LONG,
@@ -749,8 +749,11 @@ export default function useGameEngine() {
     // generate a velocity based on the entry edge
     const genVelocity = () => {
       const factor = difficultyFactor();
-      const main = (Math.random() * 2 + 1) * factor;
-      const cross = (Math.random() * 2 - 1) * factor;
+      const range = FISH_SPEED_MAX - FISH_SPEED_MIN;
+      const main =
+        (Math.random() * range + FISH_SPEED_MIN) * factor;
+      const cross =
+        (Math.random() * range - range / 2) * factor;
       switch (edge) {
         case 0:
           return { vx: main, vy: cross };


### PR DESCRIPTION
## Summary
- calculate fish speed using `FISH_SPEED_MIN`/`FISH_SPEED_MAX`
- scale velocities by difficulty factor

## Testing
- `npm run lint`
- `npm test` *(fails: jest-environment-jsdom cannot be found)*


------
https://chatgpt.com/codex/tasks/task_e_688daee8f024832bbc9cbc9ca2f4b6ae