### PR TITLE
Use configured fish spawn intervals

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -871,7 +871,10 @@ export default function useGameEngine() {
     let timer: ReturnType<typeof setTimeout>;
     const schedule = () => {
       const factor = difficultyFactor();
-      const delay = (1000 + Math.random() * 2000) / factor;
+      // FISH_SPAWN_INTERVAL_* are expressed in frames; convert to ms
+      const min = (FISH_SPAWN_INTERVAL_MIN / FPS) * 1000;
+      const max = (FISH_SPAWN_INTERVAL_MAX / FPS) * 1000;
+      const delay = (min + Math.random() * (max - min)) / factor;
 
       timer = setTimeout(() => {
         if (state.current.phase !== "playing") return;


### PR DESCRIPTION
## Summary
- tie fish spawn timing to FISH_SPAWN_INTERVAL_MIN/MAX
- convert frame-based intervals to millisecond delays before scheduling

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688daef93d20832bbfd42d1c7d55cb8f