### PR TITLE
feat: add vertical velocity to text labels

### DIFF
--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -247,6 +247,7 @@ export function useGameEngine() {
           fade,
           x,
           y,
+          vy: -0.5,
           maxAge,
         },
         assetMgr,

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -85,7 +85,7 @@ export default function useGameEngine() {
   const makeText = useCallback(
     (text: string, x: number, y: number) => {
       const lbl = newTextLabel(
-        { text, scale: 1, fixed: true, fade: true, x, y },
+        { text, scale: 1, fixed: true, fade: true, x, y, vy: -0.5 },
         { getImg } as unknown as AssetMgr,
         state.current.dims
       );

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -61,6 +61,8 @@ export interface TextLabel {
   x: number;
   /** Y position (pixels) */
   y: number;
+  /** Vertical velocity (pixels per frame) */
+  vy?: number;
   /** Current age in frames */
   age: number;
   /** Maximum age before removal */

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -56,6 +56,7 @@ export function drawTextLabels({
     }
 
     // increment age for the label
+    lbl.y += lbl.vy ?? 0;
     lbl.age++;
   });
 
@@ -80,10 +81,11 @@ export function drawTextLabels({
 export function newTextLabel(
   textLabelProps: Omit<
     TextLabel,
-    "age" | "imgs" | "x" | "y" | "maxAge" | "spaceGap"
+    "age" | "imgs" | "x" | "y" | "vy" | "maxAge" | "spaceGap"
   > & {
     x?: number;
     y?: number;
+    vy?: number;
     maxAge?: number;
     spaceGap?: number;
   },
@@ -91,7 +93,7 @@ export function newTextLabel(
   dims?: Dims
 ): TextLabel {
   // destructure properties from textLabelProps
-  const { text, scale, fixed, fade, x, y, maxAge, onClick } = textLabelProps;
+  const { text, scale, fixed, fade, x, y, vy, maxAge, onClick } = textLabelProps;
   let { spaceGap } = textLabelProps;
 
   // get images from asset manager
@@ -145,6 +147,7 @@ export function newTextLabel(
     fade,
     x: posX,
     y: posY,
+    vy: vy ?? 0,
     age: 0,
     maxAge: maxAge ? maxAge : fade ? 60 : Infinity,
     spaceGap,


### PR DESCRIPTION
## Summary
- allow TextLabel to include optional vertical velocity and apply movement during drawing
- update game engines to spawn floating text labels that drift upward

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: FISH_SPAWN_INTERVAL_MIN/MAX defined but never used in useGameEngine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_688daf21336c832ba2898f87e2cd8c44