### PR TITLE
feat: highlight special fish variants

### DIFF
--- a/src/games/zombiefish/hooks/useGameAssets.ts
+++ b/src/games/zombiefish/hooks/useGameAssets.ts
@@ -38,10 +38,13 @@ export function useGameAssets(): {
     const fishTypes = [
       "blue",
       "brown",
+      "brown_outline",
       "green",
       "grey",
       "grey_long_a",
+      "grey_long_a_outline",
       "grey_long_b",
+      "grey_long_b_outline",
       "orange",
       "pink",
       "red",

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -434,7 +434,12 @@ export default function useGameEngine() {
       const imgMap = getImg(
         f.isSkeleton ? "skeletonImgs" : "fishImgs"
       ) as Record<string, HTMLImageElement>;
-      const img = imgMap[f.kind as keyof typeof imgMap];
+      const key = f.isSkeleton
+        ? f.kind
+        : f.highlight
+        ? `${f.kind}_outline`
+        : f.kind;
+      const img = imgMap[key as keyof typeof imgMap];
       if (!img) return;
       ctx.save();
       ctx.translate(f.x + FISH_SIZE / 2, f.y + FISH_SIZE / 2);
@@ -497,7 +502,12 @@ export default function useGameEngine() {
         const imgMap = getImg(
           f.isSkeleton ? "skeletonImgs" : "fishImgs"
         ) as Record<string, HTMLImageElement>;
-        const img = imgMap[f.kind as keyof typeof imgMap];
+        const key = f.isSkeleton
+          ? f.kind
+          : f.highlight
+          ? `${f.kind}_outline`
+          : f.kind;
+        const img = imgMap[key as keyof typeof imgMap];
         if (!img) return;
         ctx.save();
         ctx.translate(f.x + FISH_SIZE / 2, f.y + FISH_SIZE / 2);
@@ -894,7 +904,13 @@ export default function useGameEngine() {
     };
 
     // helper to create a fish
-    const makeFish = (k: string, x: number, y: number, groupId?: number) => {
+    const makeFish = (
+      k: string,
+      x: number,
+      y: number,
+      groupId?: number,
+      highlight = false
+    ) => {
       const { vx, vy } = genVelocity();
       return {
         id: nextFishId.current++,
@@ -906,6 +922,7 @@ export default function useGameEngine() {
         ...(k === "skeleton" ? { health: 2 } : {}),
         isSkeleton: k === "skeleton",
         ...(groupId !== undefined ? { groupId } : {}),
+        ...(highlight ? { highlight: true } : {}),
       } as Fish;
     };
 
@@ -929,6 +946,7 @@ export default function useGameEngine() {
             ...(kind === "skeleton" ? { health: 2 } : {}),
             isSkeleton: kind === "skeleton",
             ...(groupId !== undefined ? { groupId } : {}),
+            highlight: true,
           } as Fish);
         });
       } else {
@@ -948,6 +966,7 @@ export default function useGameEngine() {
             ...(kind === "skeleton" ? { health: 2 } : {}),
             isSkeleton: kind === "skeleton",
             ...(groupId !== undefined ? { groupId } : {}),
+            highlight: true,
           } as Fish);
         });
       }
@@ -970,13 +989,27 @@ export default function useGameEngine() {
 
       if (groupId === undefined) {
         for (let i = 0; i < count; i++) {
-          spawned.push(makeFish(kind, x, y, groupId));
+          spawned.push(
+            makeFish(kind, x, y, groupId, specialSingles.includes(kind))
+          );
         }
       } else {
-        const leader = makeFish(kind, x, y, groupId);
+        const leader = makeFish(
+          kind,
+          x,
+          y,
+          groupId,
+          specialSingles.includes(kind)
+        );
         spawned.push(leader);
         for (let i = 1; i < count; i++) {
-          const member = makeFish(kind, leader.x, leader.y, groupId);
+          const member = makeFish(
+            kind,
+            leader.x,
+            leader.y,
+            groupId,
+            specialSingles.includes(kind)
+          );
           member.x = leader.x + (Math.random() - 0.5) * FISH_SIZE;
           member.y = Math.min(
             Math.max(leader.y + (Math.random() - 0.5) * FISH_SIZE, 0),

--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -20,6 +20,8 @@ export interface Fish {
    * Special fish spawn without a groupId.
    */
   groupId?: number;
+  /** Whether this fish should draw with a highlighted variant */
+  highlight?: boolean;
   /** Whether this fish has turned into a skeleton */
   isSkeleton?: boolean;
 }


### PR DESCRIPTION
## Summary
- load outline variants for special fish in asset manager
- mark special fish with a `highlight` flag when spawning
- render highlighted fish using outline sprites

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688db64b4ecc832b890cf43f3fc17565