### PR TITLE
feat(zombiefish): cap skeleton count

### DIFF
--- a/src/games/zombiefish/constants.ts
+++ b/src/games/zombiefish/constants.ts
@@ -24,6 +24,9 @@ export const FISH_SPEED_MAX = 3;
 // Speed at which skeleton fish chase others.
 export const SKELETON_SPEED = 2;
 
+// Maximum number of skeleton fish allowed simultaneously.
+export const MAX_SKELETONS = 20;
+
 // Time adjustments when hitting special fish (in seconds).
 export const TIME_BONUS_BROWN_FISH = 3;
 export const TIME_PENALTY_GREY_LONG = 5;

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -11,6 +11,7 @@ import {
   FISH_SPAWN_INTERVAL_MIN,
   FISH_SPAWN_INTERVAL_MAX,
   SKELETON_SPEED,
+  MAX_SKELETONS,
   TIME_BONUS_BROWN_FISH,
   TIME_PENALTY_GREY_LONG,
   DEFAULT_CURSOR,
@@ -230,6 +231,7 @@ export default function useGameEngine() {
     const base = SKELETON_SPEED;
     const extra = SKELETON_SPEED;
     const skeletonSpeed = base + (1 - cur.timer / GAME_TIME) * extra;
+    let skeletonCount = cur.fish.filter((f) => f.isSkeleton).length;
     cur.fish.forEach((s) => {
       if (!s.isSkeleton) return;
 
@@ -258,7 +260,8 @@ export default function useGameEngine() {
         }
         if (
           dist < SKELETON_CONVERT_DISTANCE &&
-          !immuneKinds.has(nearest.kind)
+          !immuneKinds.has(nearest.kind) &&
+          skeletonCount < MAX_SKELETONS
         ) {
           // Spawn a brief text effect before converting the fish
           makeText("POOF", nearest.x, nearest.y);
@@ -268,6 +271,7 @@ export default function useGameEngine() {
           nearest.vy = 0;
           delete nearest.groupId;
           audio.play("convert");
+          skeletonCount += 1;
         }
       }
 
@@ -811,8 +815,9 @@ export default function useGameEngine() {
             cur.fish = cur.fish.filter((fish) => fish.groupId !== gid);
             audio.play("penalty");
           } else {
+            const skeletonCount = cur.fish.filter((fish) => fish.isSkeleton).length;
             if (!f.isSkeleton) {
-              if (Math.random() < 0.5) {
+              if (Math.random() < 0.5 && skeletonCount < MAX_SKELETONS) {
                 f.isSkeleton = true;
                 f.health = 1;
                 audio.play("skeleton");


### PR DESCRIPTION
## Summary
- add `MAX_SKELETONS` constant to Zombiefish
- limit skeleton conversions when cap reached

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688db6631500832ba46aff3319a8d134