### PR TITLE
feat: change crosshair when hovering fish

### DIFF
--- a/src/games/zombiefish/components/GameUI.tsx
+++ b/src/games/zombiefish/components/GameUI.tsx
@@ -10,6 +10,7 @@ export interface GameUIProps {
   cursor: string;
   handleClick: (e: React.MouseEvent) => void;
   handleContext: (e: React.MouseEvent) => void;
+  handleMouseMove: (e: React.MouseEvent) => void;
 }
 
 // Minimal in-game UI
@@ -19,6 +20,7 @@ export function GameUI({
   cursor,
   handleClick,
   handleContext,
+  handleMouseMove,
 }: GameUIProps) {
   const { phase, cursor } = ui;
 
@@ -28,6 +30,7 @@ export function GameUI({
         ref={canvasRef}
         onClick={handleClick}
         onContextMenu={handleContext}
+        onMouseMove={handleMouseMove}
         style={{ display: "block", width: "100%", height: "100%", cursor }}
       />
       {phase === "gameover" && (

--- a/src/games/zombiefish/constants.ts
+++ b/src/games/zombiefish/constants.ts
@@ -9,6 +9,8 @@ export const DEFAULT_CURSOR =
   `url('${BASE_PATH}/assets/shooting-gallery/PNG/HUD/crosshair_blue_small.png') 16 16, auto`;
 export const SHOT_CURSOR =
   `url('${BASE_PATH}/assets/shooting-gallery/PNG/HUD/crosshair_white_small.png') 16 16, auto`;
+export const TARGET_CURSOR =
+  `url('${BASE_PATH}/assets/shooting-gallery/PNG/HUD/crosshair_red_small.png') 16 16, auto`;
 
 // Background color representing the underwater environment
 export const SKY_COLOR = "#1d8fde";

--- a/src/games/zombiefish/index.tsx
+++ b/src/games/zombiefish/index.tsx
@@ -13,6 +13,7 @@ export default function Game() {
   const {
     ui,
     canvasRef,
+    handleMouseMove,
     handleClick,
     handleContext,
     startSplash,
@@ -59,6 +60,7 @@ export default function Game() {
       cursor={ui.cursor}
       handleClick={handleClick}
       handleContext={handleContext}
+      handleMouseMove={handleMouseMove}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add red hover crosshair constant
- switch cursor to red crosshair when hovering over fish
- plumb handleMouseMove through game engine and UI

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688db6bfb62c832b86806f9153b6040c