### PR TITLE
Add red flash when damaged fish survives hit

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -32,6 +32,7 @@ const BUBBLE_SIZE = 64;
 const ROCK_SPEED = 0.2;
 const SEAWEED_SPEED = 0.4;
 const MAX_BUBBLES = 20;
+const HURT_FRAMES = 10;
 
 export default function useGameEngine() {
   // canvas and animation frame refs
@@ -281,6 +282,7 @@ export default function useGameEngine() {
 
     // move fish with a slight oscillation and update their angle
     cur.fish.forEach((f) => {
+      if (f.hurtTimer && f.hurtTimer > 0) f.hurtTimer -= 1;
       const osc = Math.sin((frameRef.current + f.id) / 20) * 0.5;
       const vy = f.vy + osc;
       f.x += f.vx;
@@ -441,6 +443,10 @@ export default function useGameEngine() {
       if (f.vx < 0) ctx.scale(-1, 1);
       ctx.rotate(f.angle);
       ctx.drawImage(img, -FISH_SIZE / 2, -FISH_SIZE / 2, FISH_SIZE, FISH_SIZE);
+      if (f.hurtTimer && f.hurtTimer > 0) {
+        ctx.fillStyle = "rgba(255,0,0,0.5)";
+        ctx.fillRect(-FISH_SIZE / 2, -FISH_SIZE / 2, FISH_SIZE, FISH_SIZE);
+      }
       ctx.restore();
     });
 
@@ -510,6 +516,10 @@ export default function useGameEngine() {
           FISH_SIZE,
           FISH_SIZE
         );
+        if (f.hurtTimer && f.hurtTimer > 0) {
+          ctx.fillStyle = "rgba(255,0,0,0.5)";
+          ctx.fillRect(-FISH_SIZE / 2, -FISH_SIZE / 2, FISH_SIZE, FISH_SIZE);
+        }
         ctx.restore();
       });
 
@@ -826,6 +836,7 @@ export default function useGameEngine() {
                 cur.fish.splice(i, 1);
                 audio.play("death");
               } else {
+                f.hurtTimer = HURT_FRAMES;
                 audio.play("skeleton");
               }
             }

--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -15,6 +15,8 @@ export interface Fish {
   angle: number;
   /** Health points, used by skeleton fish. */
   health?: number;
+  /** Frames remaining for the red flash after taking damage. */
+  hurtTimer?: number;
   /**
    * Optional identifier tying fish together when spawned in a group.
    * Special fish spawn without a groupId.


### PR DESCRIPTION
## Summary
- add `hurtTimer` property and `HURT_FRAMES` constant to manage brief damage flashes
- draw a semi-transparent red overlay when a skeleton fish takes non-lethal damage

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688db6d6310c832b83d3541a91c6f543