### PR TITLE
Pulse accuracy label after game over

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -405,27 +405,27 @@ export default function useGameEngine() {
         lbl.imgs = initImgs;
         accuracyLabel.current = lbl;
         cur.textLabels.push(lbl);
-      } else {
-        const lbl = accuracyLabel.current;
-        if (displayAccuracy.current < finalAccuracy.current) {
-          displayAccuracy.current += 1;
-          audio.play("tick");
-          const pct = Math.min(displayAccuracy.current, finalAccuracy.current);
-          const str = pct.toString();
-          const digitImgs = getImg("digitImgs") as Record<
-            string,
-            HTMLImageElement
-          >;
-          const pctImg = getImg("pctImg") as HTMLImageElement;
-          lbl.text = `${str}%`;
-          lbl.imgs = [...str.split("").map((ch) => digitImgs[ch]), pctImg];
-          const totalWidth = lbl.imgs.reduce(
-            (w, img) => w + (img?.width || 0) * lbl.scale + 2,
-            0
-          );
-          lbl.x = (cur.dims.width - totalWidth) / 2;
-        }
       }
+
+      const lbl = accuracyLabel.current!;
+      if (displayAccuracy.current < finalAccuracy.current) {
+        displayAccuracy.current += 1;
+        audio.play("tick");
+        const pct = Math.min(displayAccuracy.current, finalAccuracy.current);
+        const str = pct.toString();
+        const digitImgs = getImg("digitImgs") as Record<string, HTMLImageElement>;
+        const pctImg = getImg("pctImg") as HTMLImageElement;
+        lbl.text = `${str}%`;
+        lbl.imgs = [...str.split("").map((ch) => digitImgs[ch]), pctImg];
+      }
+
+      // pulse the accuracy label slightly each frame
+      lbl.scale = 1 + 0.05 * Math.sin(frameRef.current * 0.1);
+      const totalWidth = lbl.imgs.reduce(
+        (w, img) => w + (img?.width || 0) * lbl.scale + 2,
+        0
+      );
+      lbl.x = (cur.dims.width - totalWidth) / 2;
     }
 
     drawBackground(ctx);

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -63,6 +63,8 @@ export interface TextLabel {
   y: number;
   /** Vertical velocity (pixels per frame) */
   vy?: number;
+  /** Change in scale per frame */
+  vs?: number;
   /** Current age in frames */
   age: number;
   /** Maximum age before removal */

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -57,6 +57,7 @@ export function drawTextLabels({
 
     // increment age for the label
     lbl.y += lbl.vy ?? 0;
+    lbl.scale += lbl.vs ?? 0;
     lbl.age++;
   });
 
@@ -81,11 +82,12 @@ export function drawTextLabels({
 export function newTextLabel(
   textLabelProps: Omit<
     TextLabel,
-    "age" | "imgs" | "x" | "y" | "vy" | "maxAge" | "spaceGap"
+    "age" | "imgs" | "x" | "y" | "vy" | "vs" | "maxAge" | "spaceGap"
   > & {
     x?: number;
     y?: number;
     vy?: number;
+    vs?: number;
     maxAge?: number;
     spaceGap?: number;
   },
@@ -93,7 +95,8 @@ export function newTextLabel(
   dims?: Dims
 ): TextLabel {
   // destructure properties from textLabelProps
-  const { text, scale, fixed, fade, x, y, vy, maxAge, onClick } = textLabelProps;
+  const { text, scale, fixed, fade, x, y, vy, vs, maxAge, onClick } =
+    textLabelProps;
   let { spaceGap } = textLabelProps;
 
   // get images from asset manager
@@ -148,6 +151,7 @@ export function newTextLabel(
     x: posX,
     y: posY,
     vy: vy ?? 0,
+    vs: vs ?? 0,
     age: 0,
     maxAge: maxAge ? maxAge : fade ? 60 : Infinity,
     spaceGap,


### PR DESCRIPTION
## Summary
- add per-frame scale velocity to `TextLabel` and apply it in `drawTextLabels`
- pulse the game-over accuracy label in the Zombiefish engine with a sinusoidal scale

## Testing
- `npm run lint`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found; install attempt resulted in 403)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Duplicate identifier 'cursor'; Type 'null' is not assignable to type 'HTMLAudioElement')*

------
https://chatgpt.com/codex/tasks/task_e_688db71bc7fc832bb96d344ae6020abe