### PR TITLE
Handle touch input on game canvases

### DIFF
--- a/src/games/straightcash/components/GameUI.tsx
+++ b/src/games/straightcash/components/GameUI.tsx
@@ -150,6 +150,16 @@ export default function GameUI({
         ref={canvasRef}
         onClick={handleClick}
         onContextMenu={handleContext}
+        onTouchStart={(e) => {
+          e.preventDefault();
+          const touch = e.touches[0];
+          handleClick(
+            {
+              clientX: touch.clientX,
+              clientY: touch.clientY,
+            } as unknown as React.MouseEvent<HTMLCanvasElement>
+          );
+        }}
         style={{
           position: "absolute",
           top: 0,

--- a/src/games/warbirds/components/GameUI.tsx
+++ b/src/games/warbirds/components/GameUI.tsx
@@ -196,6 +196,16 @@ export function GameUI({
         ref={canvasRef}
         onClick={handleClick}
         onContextMenu={handleContext}
+        onTouchStart={(e) => {
+          e.preventDefault();
+          const touch = e.touches[0];
+          handleClick(
+            {
+              clientX: touch.clientX,
+              clientY: touch.clientY,
+            } as unknown as React.MouseEvent<HTMLCanvasElement>
+          );
+        }}
         style={{
           display: "block",
           width: "100%",

--- a/src/games/zombiefish/components/GameUI.tsx
+++ b/src/games/zombiefish/components/GameUI.tsx
@@ -28,6 +28,16 @@ export function GameUI({
         ref={canvasRef}
         onClick={handleClick}
         onContextMenu={handleContext}
+        onTouchStart={(e) => {
+          e.preventDefault();
+          const touch = e.touches[0];
+          handleClick(
+            {
+              clientX: touch.clientX,
+              clientY: touch.clientY,
+            } as unknown as React.MouseEvent<HTMLCanvasElement>
+          );
+        }}
         style={{ display: "block", width: "100%", height: "100%", cursor }}
       />
       {phase === "gameover" && (


### PR DESCRIPTION
## Summary
- forward touch events to existing click handlers in each GameUI canvas
- prevent default scrolling on touch start

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688db71ec61c832baa778653c5d839e5