### PR TITLE
feat: track zombie conversions

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -58,6 +58,7 @@ export default function useGameEngine() {
     fish: [],
     bubbles: [],
     textLabels: [],
+    conversions: 0,
   });
 
   const nextFishId = useRef(1);
@@ -227,8 +228,9 @@ export default function useGameEngine() {
 
     // skeleton behavior
     const immuneKinds = new Set(["brown", "grey_long_a", "grey_long_b"]);
-    const base = SKELETON_SPEED;
-    const extra = SKELETON_SPEED;
+    const speedMult = 1 + cur.conversions * 0.1;
+    const base = SKELETON_SPEED * speedMult;
+    const extra = SKELETON_SPEED * speedMult;
     const skeletonSpeed = base + (1 - cur.timer / GAME_TIME) * extra;
     cur.fish.forEach((s) => {
       if (!s.isSkeleton) return;
@@ -267,6 +269,7 @@ export default function useGameEngine() {
           nearest.vx = 0;
           nearest.vy = 0;
           delete nearest.groupId;
+          cur.conversions += 1;
           audio.play("convert");
         }
       }
@@ -666,6 +669,7 @@ export default function useGameEngine() {
     cur.shots = 0;
     cur.hits = 0;
     cur.accuracy = 0;
+    cur.conversions = 0;
     cur.fish = [];
     cur.cursor = DEFAULT_CURSOR;
     cur.bubbles = [];

--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -61,4 +61,6 @@ export interface GameState extends GameUIState {
   bubbles: Bubble[];
   /** Floating text labels currently displayed */
   textLabels: TextLabel[];
+  /** Total number of fish converted into skeletons */
+  conversions: number;
 }


### PR DESCRIPTION
## Summary
- track total zombie conversions and adjust skeleton speed accordingly
- reset conversion count when returning to title screen

## Testing
- `npm run lint`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688db728923c832bbe955dfa2bdfb271