### PR TITLE
Animate zombiefish with spritesheet frames

### DIFF
--- a/src/games/zombiefish/hooks/useGameAssets.ts
+++ b/src/games/zombiefish/hooks/useGameAssets.ts
@@ -34,33 +34,60 @@ export function useGameAssets(): {
         ])
       );
 
-    // FISH IMAGES
-    const fishTypes = [
-      "blue",
-      "brown",
-      "green",
-      "grey",
-      "grey_long_a",
-      "grey_long_b",
-      "orange",
-      "pink",
-      "red",
-    ];
-    assetRefs.current.fishImgs = Object.fromEntries(
-      fishTypes.map((name) => [
-        name,
-        loadImg(`/assets/fish/PNG/Objects/Fish/fish_${name}.png`),
-      ])
-    );
+    // FISH FRAMES FROM SPRITESHEET
+    const sheet = loadImg("/assets/fish/Spritesheet/spritesheet.png");
+    const FISH_SIZE = 128;
+    const fishCoords: Record<string, [number, number][]> = {
+      blue: [[1152, 256]],
+      brown: [[1024, 1280]],
+      green: [[1024, 1024]],
+      grey: [[1024, 512]],
+      grey_long_a: [[1024, 384]],
+      grey_long_b: [[1024, 128]],
+      orange: [[896, 1280]],
+      pink: [[896, 768]],
+      red: [[896, 256]],
+    };
+    const skeletonCoords: Record<string, [number, number][]> = {
+      blue: [[1152, 0]],
+      green: [[1024, 768]],
+      orange: [[896, 1024]],
+      pink: [[896, 512]],
+      red: [[896, 0]],
+    };
 
-    // SKELETON IMAGES
-    const skeletonTypes = ["blue", "green", "orange", "pink", "red"];
-    assetRefs.current.skeletonImgs = Object.fromEntries(
-      skeletonTypes.map((name) => [
-        name,
-        loadImg(`/assets/fish/PNG/Objects/Fish/fish_${name}_skeleton.png`),
-      ])
-    );
+    sheet.onload = () => {
+      const makeFrames = (coords: Record<string, [number, number][]>) =>
+        Object.fromEntries(
+          Object.entries(coords).map(([kind, arr]) => [
+            kind,
+            arr.map(([sx, sy]) => {
+              const canvas = document.createElement("canvas");
+              canvas.width = FISH_SIZE;
+              canvas.height = FISH_SIZE;
+              const ctx = canvas.getContext("2d");
+              ctx?.drawImage(
+                sheet,
+                sx,
+                sy,
+                FISH_SIZE,
+                FISH_SIZE,
+                0,
+                0,
+                FISH_SIZE,
+                FISH_SIZE
+              );
+              const img = new window.Image();
+              img.src = canvas.toDataURL();
+              return img;
+            }),
+          ])
+        );
+
+      assetRefs.current.fishFrames = makeFrames(fishCoords);
+      assetRefs.current.skeletonFrames = makeFrames(skeletonCoords);
+      setReady(true);
+    };
 
     // OBJECTS
     assetRefs.current.bubbleImgs = build("Objects/Bubbles", [
@@ -188,7 +215,6 @@ export function useGameAssets(): {
       }
     }
 
-    setReady(true);
   }, []);
 
   const get = useCallback<AssetMgr["get"]>(

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -27,6 +27,7 @@ const GAME_TIME = 99;
 const FPS = 60; // assumed frame rate for requestAnimationFrame
 
 const FISH_SIZE = 128;
+const FISH_FRAME_DELAY = 6;
 const SKELETON_CONVERT_DISTANCE = FISH_SIZE / 2;
 const BUBBLE_SIZE = 64;
 const ROCK_SPEED = 0.2;
@@ -266,6 +267,8 @@ export default function useGameEngine() {
           nearest.health = 2;
           nearest.vx = 0;
           nearest.vy = 0;
+          nearest.frame = 0;
+          nearest.frameCounter = 0;
           delete nearest.groupId;
           audio.play("convert");
         }
@@ -431,11 +434,17 @@ export default function useGameEngine() {
     drawBackground(ctx);
 
     cur.fish.forEach((f) => {
-      const imgMap = getImg(
-        f.isSkeleton ? "skeletonImgs" : "fishImgs"
-      ) as Record<string, HTMLImageElement>;
-      const img = imgMap[f.kind as keyof typeof imgMap];
-      if (!img) return;
+      const frameMap = getImg(
+        f.isSkeleton ? "skeletonFrames" : "fishFrames"
+      ) as Record<string, HTMLImageElement[]>;
+      const frames = frameMap[f.kind as keyof typeof frameMap];
+      if (!frames || frames.length === 0) return;
+      f.frameCounter++;
+      if (f.frameCounter >= FISH_FRAME_DELAY) {
+        f.frameCounter = 0;
+        f.frame = (f.frame + 1) % frames.length;
+      }
+      const img = frames[f.frame];
       ctx.save();
       ctx.translate(f.x + FISH_SIZE / 2, f.y + FISH_SIZE / 2);
       if (f.vx < 0) ctx.scale(-1, 1);
@@ -494,11 +503,17 @@ export default function useGameEngine() {
       });
 
       cur.fish.forEach((f) => {
-        const imgMap = getImg(
-          f.isSkeleton ? "skeletonImgs" : "fishImgs"
-        ) as Record<string, HTMLImageElement>;
-        const img = imgMap[f.kind as keyof typeof imgMap];
-        if (!img) return;
+        const frameMap = getImg(
+          f.isSkeleton ? "skeletonFrames" : "fishFrames"
+        ) as Record<string, HTMLImageElement[]>;
+        const frames = frameMap[f.kind as keyof typeof frameMap];
+        if (!frames || frames.length === 0) return;
+        f.frameCounter++;
+        if (f.frameCounter >= FISH_FRAME_DELAY) {
+          f.frameCounter = 0;
+          f.frame = (f.frame + 1) % frames.length;
+        }
+        const img = frames[f.frame];
         ctx.save();
         ctx.translate(f.x + FISH_SIZE / 2, f.y + FISH_SIZE / 2);
         if (f.vx < 0) ctx.scale(-1, 1);
@@ -815,6 +830,8 @@ export default function useGameEngine() {
               if (Math.random() < 0.5) {
                 f.isSkeleton = true;
                 f.health = 1;
+                f.frame = 0;
+                f.frameCounter = 0;
                 audio.play("skeleton");
               } else {
                 cur.fish.splice(i, 1);
@@ -903,6 +920,8 @@ export default function useGameEngine() {
         y,
         vx,
         vy,
+        frame: 0,
+        frameCounter: 0,
         ...(k === "skeleton" ? { health: 2 } : {}),
         isSkeleton: k === "skeleton",
         ...(groupId !== undefined ? { groupId } : {}),
@@ -929,6 +948,8 @@ export default function useGameEngine() {
             ...(kind === "skeleton" ? { health: 2 } : {}),
             isSkeleton: kind === "skeleton",
             ...(groupId !== undefined ? { groupId } : {}),
+            frame: 0,
+            frameCounter: 0,
           } as Fish);
         });
       } else {
@@ -948,6 +969,8 @@ export default function useGameEngine() {
             ...(kind === "skeleton" ? { health: 2 } : {}),
             isSkeleton: kind === "skeleton",
             ...(groupId !== undefined ? { groupId } : {}),
+            frame: 0,
+            frameCounter: 0,
           } as Fish);
         });
       }

--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -13,6 +13,10 @@ export interface Fish {
   vy: number;
   /** Current drawing angle in radians based on velocity. */
   angle: number;
+  /** Current animation frame index */
+  frame: number;
+  /** Counter used to time frame changes */
+  frameCounter: number;
   /** Health points, used by skeleton fish. */
   health?: number;
   /**


### PR DESCRIPTION
## Summary
- load fish and skeleton frames from the shared spritesheet
- track animation frame and counter in fish state
- draw fish by advancing their frame index each tick

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688db739cc60832b93b193b7f3356883