### PR TITLE
feat: add game audio manager

### DIFF
--- a/src/games/zombiefish/hooks/useGameAudio.ts
+++ b/src/games/zombiefish/hooks/useGameAudio.ts
@@ -32,7 +32,7 @@ export function useGameAudio(): AudioMgr {
     skeleton.preload = "auto";
 
     const death = document.createElement("audio");
-    death.src = "/audio/lowDown.ogg";
+    death.src = withBasePath("/audio/lowDown.ogg");
     death.preload = "auto";
 
     const convert = document.createElement("audio");
@@ -53,9 +53,14 @@ export function useGameAudio(): AudioMgr {
 
   // Play a sound by key
   const play = useCallback(
-    (key: string) => {
+    (
+      key: string,
+      options?: { loop?: boolean; volume?: number }
+    ) => {
       const audio = audios[key];
       if (audio) {
+        if (options?.loop !== undefined) audio.loop = options.loop;
+        if (options?.volume !== undefined) audio.volume = options.volume;
         audio.currentTime = 0;
         void audio.play();
       }

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -40,7 +40,6 @@ const BUBBLE_VY_MIN = -1.5;
 const BUBBLE_VY_MAX = -0.5;
 const ROCK_SPEED = 0.2;
 const SEAWEED_SPEED = 0.4;
-const BUBBLE_SIZE = BUBBLE_BASE_SIZE;
 const ROCK_SPEED = [0.1, 0.2];
 const SEAWEED_SPEED = [0.2, 0.4];
 const MAX_BUBBLES = 20;
@@ -313,7 +312,7 @@ export default function useGameEngine() {
         if (
           dist < SKELETON_CONVERT_DISTANCE &&
           !immuneKinds.has(nearest.kind) &&
-          skeletonCount < MAX_SKELETONS
+          skeletonCount < MAX_SKELETONS &&
           !nearest.pendingSkeleton
         ) {
           // Spawn a brief text effect before converting the fish
@@ -560,8 +559,7 @@ export default function useGameEngine() {
           );
           cur.textLabels.push(pausedLabel.current);
         }
-      } 
-    (pausedLabel.current) {
+      } else if (pausedLabel.current) {
         cur.textLabels = cur.textLabels.filter((l) => l !== pausedLabel.current);
         pausedLabel.current = null;
       }
@@ -656,7 +654,7 @@ export default function useGameEngine() {
     const digitHeight = digitImgs["0"]?.height || 0;
     const lineHeight = digitHeight + 8;
 
-    audio.play("bgm");
+    audio.play("bgm", { loop: true });
 
     const labelWidth = (lbl: TextLabel) =>
       lbl.imgs.reduce(


### PR DESCRIPTION
## Summary
- load all Zombie Fish sounds with `withBasePath`
- expose AudioMgr play/pause helpers
- loop background music while playing

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dbe41ab38832bbfe8b40f5ca2ccc4