### PR TITLE
Manage Zombie Fish background music

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -853,6 +853,7 @@ export default function useGameEngine() {
       clearTimeout(cursorTimeoutRef.current);
       cursorTimeoutRef.current = null;
     }
+    audio.pause("bgm");
     audio.pauseAll();
   }, []);
 


### PR DESCRIPTION
## Summary
- Use `useGameAudio` to provide play/pause helpers for core sound effects
- Play shot and fish reaction audio in `handleClick`
- Start looping BGM at game start and pause it when resetting

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install jest-environment-jsdom --no-save` *(fails: 403 Forbidden)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dc9c34ef8832ba8bd0fc68488b56a