### PR TITLE
feat: support touch input in game canvas

### DIFF
--- a/src/games/straightcash/components/GameUI.tsx
+++ b/src/games/straightcash/components/GameUI.tsx
@@ -4,6 +4,7 @@ import Button from "@mui/material/Button";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Typography from "@mui/material/Typography";
+import type { ClickEvent } from "@/types/events";
 import Reel from "./Reel";
 import BonusWheel from "./BonusWheel";
 import JackpotDisplay, { JackpotHandle } from "./JackpotDisplay";
@@ -13,7 +14,7 @@ export interface GameUIProps {
   cursor: string;
   onShot: () => void;
   canvasRef: React.RefObject<HTMLCanvasElement | null>;
-  handleClick: (e: React.MouseEvent) => void;
+  handleClick: (e: ClickEvent) => void;
   handleContext: (e: React.MouseEvent) => void;
   startSpins: (amount: number, denom: number) => void;
   spinning: boolean[];
@@ -153,12 +154,10 @@ export default function GameUI({
         onTouchStart={(e) => {
           e.preventDefault();
           const touch = e.touches[0];
-          handleClick(
-            {
-              clientX: touch.clientX,
-              clientY: touch.clientY,
-            } as unknown as React.MouseEvent<HTMLCanvasElement>
-          );
+          handleClick({
+            clientX: touch.clientX,
+            clientY: touch.clientY,
+          });
         }}
         style={{
           position: "absolute",

--- a/src/games/straightcash/hooks/useStraightCashGameEngine.ts
+++ b/src/games/straightcash/hooks/useStraightCashGameEngine.ts
@@ -4,6 +4,7 @@ import { AudioMgr } from "@/types/audio";
 import { TextLabel } from "@/types/ui";
 import { drawTextLabels } from "@/utils/ui";
 import useStraightCashAudio from "./useStraightCashAudio";
+import type { ClickEvent } from "@/types/events";
 import type { JackpotHandle } from "../components/JackpotDisplay";
 
 const REEL_RANKS = [
@@ -197,7 +198,8 @@ export default function useStraightCashGameEngine() {
     []
   );
 
-  const handleClick = useCallback(() => {
+  const handleClick = useCallback((e: ClickEvent) => {
+    void e;
     // placeholder for gameplay interaction
   }, []);
 

--- a/src/games/warbirds/components/GameUI.tsx
+++ b/src/games/warbirds/components/GameUI.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Box from "@mui/material/Box";
+import type { ClickEvent } from "@/types/events";
 import { PowerupType } from "@/types/objects";
 import {
   SCORE_LABEL_SRC,
@@ -18,7 +19,7 @@ import { GameUIState } from "../types";
 export interface GameUIProps {
   ui: GameUIState;
   canvasRef: React.RefObject<HTMLCanvasElement | null>;
-  handleClick: (e: React.MouseEvent) => void;
+  handleClick: (e: ClickEvent) => void;
   handleContext: (e: React.MouseEvent) => void;
   resetGame: () => void;
   getImg: (
@@ -199,12 +200,10 @@ export function GameUI({
         onTouchStart={(e) => {
           e.preventDefault();
           const touch = e.touches[0];
-          handleClick(
-            {
-              clientX: touch.clientX,
-              clientY: touch.clientY,
-            } as unknown as React.MouseEvent<HTMLCanvasElement>
-          );
+          handleClick({
+            clientX: touch.clientX,
+            clientY: touch.clientY,
+          });
         }}
         style={{
           display: "block",

--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -72,6 +72,7 @@ import { useWindowSize } from "@/hooks/useWindowSize";
 import { AudioMgr } from "@/types/audio";
 import { Puff } from "@/types/effects";
 import { PowerupType, AntiPowerupType, Duck } from "@/types/objects";
+import type { ClickEvent } from "@/types/events";
 import { AssetMgr } from "@/types/ui";
 import { Enemy } from "@/types/vehicles";
 import { useState, useRef, useCallback, useEffect } from "react";
@@ -3339,7 +3340,7 @@ export function useGameEngine() {
   }, [ui.phase, dims, canvasRef]);
 
   // ─── CLICK TO FLAP & FIRE ─────────────────────────────────────────────────
-  const handleClick = (e: React.MouseEvent) => {
+  const handleClick = (e: ClickEvent) => {
     // out of play or no ammo → reload flash
     if (ui.phase !== "playing" || ui.crashed || ui.ammo <= 0) {
       if (state.current.ammo <= 1) {

--- a/src/games/zombiefish/components/GameUI.tsx
+++ b/src/games/zombiefish/components/GameUI.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Box from "@mui/material/Box";
 import { withBasePath } from "@/utils/basePath";
+import type { ClickEvent } from "@/types/events";
 import type { GameUIState } from "../types";
 
 export interface GameUIProps {
@@ -8,7 +9,7 @@ export interface GameUIProps {
   canvasRef: React.RefObject<HTMLCanvasElement | null>;
   /** Current cursor style to display over the canvas */
   cursor: string;
-  handleClick: (e: React.MouseEvent) => void;
+  handleClick: (e: ClickEvent) => void;
   handleContext: (e: React.MouseEvent) => void;
   handleMouseMove: (e: React.MouseEvent) => void;
 }
@@ -33,12 +34,10 @@ export function GameUI({
         onTouchStart={(e) => {
           e.preventDefault();
           const touch = e.touches[0];
-          handleClick(
-            {
-              clientX: touch.clientX,
-              clientY: touch.clientY,
-            } as unknown as React.MouseEvent<HTMLCanvasElement>
-          );
+          handleClick({
+            clientX: touch.clientX,
+            clientY: touch.clientY,
+          });
         }}
         onMouseMove={handleMouseMove}
         style={{ display: "block", width: "100%", height: "100%", cursor }}

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -21,6 +21,7 @@ import {
 import type { AssetMgr } from "@/types/ui";
 import type { TextLabel } from "@/types/ui";
 import type { AudioMgr } from "@/types/audio";
+import type { ClickEvent } from "@/types/events";
 
 /* eslint-disable react-hooks/exhaustive-deps */
 
@@ -918,8 +919,8 @@ export default function useGameEngine() {
 
   // handle left click – detect and affect fish
   const handleClick = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
+    (e: ClickEvent) => {
+      e.preventDefault?.();
       const cur = state.current;
       if (cur.phase === "gameover") {
         const canvas = canvasRef.current;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,0 +1,6 @@
+export interface ClickEvent {
+  clientX: number;
+  clientY: number;
+  button?: number;
+  preventDefault?: () => void;
+}


### PR DESCRIPTION
## Summary
- support synthetic click events via new `ClickEvent` type
- trigger `handleClick` on touch start across game canvases
- adjust game engines to handle `ClickEvent` data

## Testing
- `npm test -- --env=node` *(fails: document is not defined)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dc9b286b8832b93ca445999abaaf1