### PR TITLE
Add colon-enabled timer label to Zombie Fish game

### DIFF
--- a/src/games/zombiefish/hooks/useGameAssets.ts
+++ b/src/games/zombiefish/hooks/useGameAssets.ts
@@ -200,11 +200,11 @@ export function useGameAssets(): {
         `/assets/fish/PNG/HUDText/hud_number_${n}.png`
       );
     }
-
-    assetRefs.current.dotImg = loadImg("/assets/fish/PNG/HUDText/hud_dot.png");
-    assetRefs.current.colonImg = loadImg(
+    assetRefs.current.digitImgs[":"] = loadImg(
       "/assets/fish/PNG/HUDText/hud_colon.png"
     );
+
+    assetRefs.current.dotImg = loadImg("/assets/fish/PNG/HUDText/hud_dot.png");
     assetRefs.current.pctImg = loadImg(
       "/assets/fish/PNG/HUDText/hud_percent.png"
     );

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -209,10 +209,16 @@ export default function useGameEngine() {
   );
 
   const updateDigitLabel = useCallback(
-    (label: TextLabel | null, value: number, pad = 0) => {
+    (
+      label: TextLabel | null,
+      value: number,
+      pad = 0,
+      suffix = ""
+    ) => {
       if (!label) return;
       const str =
-        pad > 0 ? value.toString().padStart(pad, "0") : value.toString();
+        (pad > 0 ? value.toString().padStart(pad, "0") : value.toString()) +
+        suffix;
       const digitImgs = getImg("digitImgs") as Record<string, HTMLImageElement>;
       label.text = str;
       label.imgs = str.split("").map((ch) => digitImgs[ch]);
@@ -394,7 +400,7 @@ export default function useGameEngine() {
       if (frameRef.current >= FPS) {
         frameRef.current = 0;
         cur.timer = Math.max(0, cur.timer - 1);
-        updateDigitLabel(timerLabel.current, cur.timer, 2);
+        updateDigitLabel(timerLabel.current, cur.timer, 2, ":");
       }
 
       // check for game over once timer hits zero
@@ -716,7 +722,7 @@ export default function useGameEngine() {
 
     timerLabel.current = newTextLabel(
       {
-        text: cur.timer.toString().padStart(2, "0"),
+        text: `${cur.timer.toString().padStart(2, "0")}:`,
         scale: 1,
         fixed: true,
         fade: false,
@@ -996,13 +1002,13 @@ export default function useGameEngine() {
           audio.play("hit");
           if (f.kind === "brown") {
             cur.timer += TIME_BONUS_BROWN_FISH;
-            updateDigitLabel(timerLabel.current, cur.timer, 2);
+            updateDigitLabel(timerLabel.current, cur.timer, 2, ":");
             makeText(`+${TIME_BONUS_BROWN_FISH}`, f.x, f.y);
             cur.fish.splice(i, 1);
             audio.play("bonus");
           } else if (f.kind === "grey_long_a" || f.kind === "grey_long_b") {
             cur.timer = Math.max(0, cur.timer - TIME_PENALTY_GREY_LONG);
-            updateDigitLabel(timerLabel.current, cur.timer, 2);
+            updateDigitLabel(timerLabel.current, cur.timer, 2, ":");
             makeText(`-${TIME_PENALTY_GREY_LONG}`, f.x, f.y);
             const gid = f.groupId;
             cur.fish = cur.fish.filter((fish) => fish.groupId !== gid);


### PR DESCRIPTION
## Summary
- load colon image with digit assets
- show timer using `newTextLabel` with trailing colon
- update digit label helper to support suffix and countdown once per second

## Testing
- `npm run lint`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688dca3f3c14832ba5a831216c704295