### PR TITLE
feat(games:zombiefish): store and display best accuracy

### DIFF
--- a/src/games/zombiefish/components/TitleSplash.tsx
+++ b/src/games/zombiefish/components/TitleSplash.tsx
@@ -28,7 +28,7 @@ export const TitleSplash: React.FC<TitleSplashProps> = ({
     canvas.height = window.innerHeight;
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
-    const best = Number(localStorage.bestAccuracy || 0);
+    const best = Number(localStorage.getItem("bestAccuracy") || 0);
     const assetMgr = { getImg } as AssetMgr;
     const lbl = newTextLabel(
       {
@@ -43,7 +43,8 @@ export const TitleSplash: React.FC<TitleSplashProps> = ({
     );
     const pctImg = getImg("pctImg") as HTMLImageElement;
     const digitImgs = getImg("digitImgs") as Record<string, HTMLImageElement>;
-    lbl.imgs = [...best.toString().split("").map((ch) => digitImgs[ch]), pctImg];
+    const digits = best.toString().split("").map((ch) => digitImgs[ch]);
+    lbl.imgs = [...digits, pctImg];
     drawTextLabels({ textLabels: [lbl], ctx });
   }, [getImg]);
 

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -85,6 +85,12 @@ export default function useGameEngine() {
   const accuracyLabel = useRef<TextLabel | null>(null);
   const finalAccuracy = useRef(0);
   const displayAccuracy = useRef(0);
+  const updateBestAccuracy = (score: number) => {
+    const best = Number(localStorage.getItem("bestAccuracy") || 0);
+    if (score > best) {
+      localStorage.setItem("bestAccuracy", score.toString());
+    }
+  };
   const bestAccuracyLabel = useRef<TextLabel | null>(null);
   const timerLabel = useRef<TextLabel | null>(null);
   const shotsLabel = useRef<TextLabel | null>(null);
@@ -401,10 +407,7 @@ export default function useGameEngine() {
       if (cur.timer === 0) {
         cur.phase = "gameover";
         finalAccuracy.current = Math.round(cur.accuracy);
-        const best = Number(localStorage.bestAccuracy || 0);
-        if (finalAccuracy.current > best) {
-          localStorage.bestAccuracy = finalAccuracy.current.toString();
-        }
+        updateBestAccuracy(finalAccuracy.current);
         displayAccuracy.current = 0;
         audio.pause("bgm");
 
@@ -460,7 +463,7 @@ export default function useGameEngine() {
         gameoverHitsLabel.current = makeStat(`HITS ${cur.hits}`, baseY + 80);
       }
       if (!bestAccuracyLabel.current) {
-        const best = Number(localStorage.bestAccuracy || 0);
+        const best = Number(localStorage.getItem("bestAccuracy") || 0);
         const pctImg = getImg("pctImg") as HTMLImageElement;
         const digitImgs = getImg("digitImgs") as Record<
           string,


### PR DESCRIPTION
## Summary
- track best accuracy in localStorage when the game ends
- show stored best accuracy on the title screen using digit images

## Testing
- `npm run lint`
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688dc9fa1478832b81c72cc4e354203e