### PR TITLE
feat(zombiefish): vary school velocity using speed constants

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -1028,6 +1028,8 @@ export default function useGameEngine() {
   const spawnFish = useCallback((kind: string, count: number): Fish[] => {
     const spawned: Fish[] = [];
     const { width, height } = state.current.dims;
+    // keep school member velocity variance tied to the configured speed range
+    const speedVariance = (FISH_SPEED_MAX - FISH_SPEED_MIN) / 4;
 
     const specialSingles = ["brown", "grey_long_a", "grey_long_b"];
     const specialPairs = ["grey_long"];
@@ -1181,8 +1183,8 @@ export default function useGameEngine() {
           }
           member.x = Math.min(Math.max(mx, 0), width - FISH_SIZE);
           member.y = my;
-          member.vx = leader.vx + (Math.random() - 0.5) * 0.5;
-          member.vy = (Math.random() - 0.5) * 0.5;
+          member.vx = leader.vx + (Math.random() - 0.5) * speedVariance;
+          member.vy = leader.vy + (Math.random() - 0.5) * speedVariance;
           spawned.push(member);
           existingPositions.push(member);
         }


### PR DESCRIPTION
## Summary
- randomize fish spawn edge and direction using FISH_SPEED_MIN/MAX
- spawn non-special fish in small schools that share a groupId
- offset each school member's speed so the group swims loosely together

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688dcebc1450832bbc3d2c945c0cc83c