### PR TITLE
feat(zombiefish): pop bubbles before fish hits

### DIFF
--- a/src/games/zombiefish/hooks/useGameAudio.ts
+++ b/src/games/zombiefish/hooks/useGameAudio.ts
@@ -39,6 +39,10 @@ export function useGameAudio(): AudioMgr {
     convert.src = withBasePath("/audio/zap1.ogg");
     convert.preload = "auto";
 
+    const pop = document.createElement("audio");
+    pop.src = withBasePath("/audio/glass_001.ogg");
+    pop.preload = "auto";
+
     const bgm = document.createElement("audio");
     bgm.src = withBasePath("/audio/back_001.ogg");
     bgm.preload = "auto";
@@ -48,7 +52,18 @@ export function useGameAudio(): AudioMgr {
     tick.src = withBasePath("/audio/tick_002.ogg");
     tick.preload = "auto";
 
-    return { shoot, hit, bonus, penalty, skeleton, death, convert, tick, bgm };
+    return {
+      shoot,
+      hit,
+      bonus,
+      penalty,
+      skeleton,
+      death,
+      convert,
+      pop,
+      tick,
+      bgm,
+    };
   }, []);
 
   // Play a sound by key

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -943,6 +943,30 @@ export default function useGameEngine() {
       const canvasY =
         ((e.clientY - rect.top) / rect.height) * cur.dims.height;
 
+      // check bubbles first so they are popped before fish hits
+      for (let i = cur.bubbles.length - 1; i >= 0; i--) {
+        const b = cur.bubbles[i];
+        if (
+          canvasX >= b.x &&
+          canvasX <= b.x + b.size &&
+          canvasY >= b.y &&
+          canvasY <= b.y + b.size
+        ) {
+          cur.bubbles.splice(i, 1);
+          audio.play("pop");
+          cur.accuracy = cur.shots > 0 ? (cur.hits / cur.shots) * 100 : 0;
+          setUI({
+            phase: cur.phase,
+            timer: cur.timer,
+            shots: cur.shots,
+            hits: cur.hits,
+            accuracy: cur.accuracy,
+            cursor: cur.cursor,
+          });
+          return;
+        }
+      }
+
       // iterate fish in reverse draw order so topmost fish are hit first
       for (let i = cur.fish.length - 1; i >= 0; i--) {
         const f = cur.fish[i];


### PR DESCRIPTION
## Summary
- pop bubbles before checking fish hits in Zombie Fish
- add a bubble pop sound to the game audio manager
- update accuracy/shot counters when popping bubbles without scoring a hit

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688dd018d27c832ba170a70ebb8dd064