### PR TITLE
Add timer progress bar to zombiefish game

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -581,6 +581,11 @@ export default function useGameEngine() {
 
       drawBackground(ctx);
 
+      // draw timer bar at top of screen
+      const barWidth = (cur.timer / GAME_TIME) * canvas.width;
+      ctx.fillStyle = "rgba(0,0,0,0.5)";
+      ctx.fillRect(0, 0, barWidth, 8);
+
       const bubbleImgs = getImg("bubbleImgs") as Record<string, HTMLImageElement>;
       cur.bubbles.forEach((b) => {
         const img = bubbleImgs[b.kind as keyof typeof bubbleImgs];


### PR DESCRIPTION
## Summary
- add semi-transparent timer bar overlay to zombiefish draw loop

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dd052ffa4832bbeae7d805cec488e