### PR TITLE
Add color support to special fish text labels

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -129,9 +129,18 @@ export default function useGameEngine() {
   }, []);
 
   const makeText = useCallback(
-    (text: string, x: number, y: number) => {
+    (text: string, x: number, y: number, color?: string) => {
       const lbl = newTextLabel(
-        { text, scale: 1, fixed: true, fade: true, x, y, vy: -0.5 },
+        {
+          text,
+          scale: 1,
+          fixed: true,
+          fade: true,
+          x,
+          y,
+          vy: -0.5,
+          ...(color ? { color } : {}),
+        },
         { getImg } as unknown as AssetMgr,
         state.current.dims
       );
@@ -958,13 +967,13 @@ export default function useGameEngine() {
           if (f.kind === "brown") {
             cur.timer += TIME_BONUS_BROWN_FISH;
             updateDigitLabel(timerLabel.current, cur.timer, 2, ":");
-            makeText(`+${TIME_BONUS_BROWN_FISH}`, f.x, f.y);
+            makeText(`+${TIME_BONUS_BROWN_FISH}`, f.x, f.y, "#ff0");
             cur.fish.splice(i, 1);
             audio.play("bonus");
           } else if (f.kind === "grey_long_a" || f.kind === "grey_long_b") {
             cur.timer = Math.max(0, cur.timer - TIME_PENALTY_GREY_LONG);
             updateDigitLabel(timerLabel.current, cur.timer, 2, ":");
-            makeText(`-${TIME_PENALTY_GREY_LONG}`, f.x, f.y);
+            makeText(`-${TIME_PENALTY_GREY_LONG}`, f.x, f.y, "#f00");
             const gid = f.groupId;
             if (gid !== undefined) {
               cur.fish = cur.fish.filter((fish) => fish.groupId !== gid);

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -71,6 +71,8 @@ export interface TextLabel {
   maxAge: number;
   /** Space between characters */
   spaceGap: number;
+  /** Optional color for text rendering */
+  color?: string;
   /** Optional click handler for interactive labels */
   onClick?: () => void;
 }

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -24,11 +24,13 @@ export function drawTextLabels({
 }): TextLabel[] {
   // get current alpha
   const prevAlpha = ctx.globalAlpha;
+  const prevFillStyle = ctx.fillStyle;
 
   textLabels.forEach((lbl) => {
     // adjust alpha for fade effect, if applicable
     const alpha = lbl.fade ? 1 - lbl.age / lbl.maxAge : 1;
     ctx.globalAlpha = alpha;
+    ctx.fillStyle = lbl.color ?? prevFillStyle;
 
     // set the starting x position
     const drawX = lbl.fixed ? lbl.x : lbl.x - (offsetX || 0);
@@ -63,6 +65,7 @@ export function drawTextLabels({
 
   // reset alpha to previous value
   ctx.globalAlpha = prevAlpha;
+  ctx.fillStyle = prevFillStyle;
 
   if (cull) {
     // if cull, remove expired labels
@@ -95,7 +98,7 @@ export function newTextLabel(
   dims?: Dims
 ): TextLabel {
   // destructure properties from textLabelProps
-  const { text, scale, fixed, fade, x, y, vy, vs, maxAge, onClick } =
+  const { text, scale, fixed, fade, x, y, vy, vs, maxAge, onClick, color } =
     textLabelProps;
   let { spaceGap } = textLabelProps;
 
@@ -155,6 +158,7 @@ export function newTextLabel(
     age: 0,
     maxAge: maxAge ? maxAge : fade ? 60 : Infinity,
     spaceGap,
+    ...(color ? { color } : {}),
     ...(onClick ? { onClick } : {}),
   };
 


### PR DESCRIPTION
## Summary
- allow `TextLabel` to carry an optional color and tint canvas drawing accordingly
- show yellow bonus and red penalty text when hitting brown or grey-long fish

## Testing
- `npm run lint`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found; install attempt returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688dd06a1ff4832b89bfcd01e863bf3e