### PR TITLE
Add miss particle effects to Zombiefish game

### DIFF
--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -49,6 +49,16 @@ export interface Bubble {
   size: number;
 }
 
+// Expanding ring drawn when a shot misses
+export interface MissParticle {
+  x: number;
+  y: number;
+  /** Current radius of the ring */
+  radius: number;
+  /** Current opacity from 1 to 0 */
+  alpha: number;
+}
+
 // State exposed to the UI layer
 export interface GameUIState {
   phase: GamePhase;
@@ -73,6 +83,8 @@ export interface GameState extends GameUIState {
   bubbles: Bubble[];
   /** Floating text labels currently displayed */
   textLabels: TextLabel[];
+  /** Ring particles displayed when shots miss */
+  missParticles: MissParticle[];
   /** Total number of fish converted into skeletons */
   conversions: number;
 }


### PR DESCRIPTION
## Summary
- show ripple ring when a shot misses a fish
- track and fade miss particles in game state

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688dd08c6430832b835e2029e12e01d3