### PR TITLE
Align grey_long fish segments with shared pairId

### DIFF
--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -26,6 +26,8 @@ export interface Fish {
    * Special fish spawn without a groupId.
    */
   groupId?: number;
+  /** Identifier used to link special multi-segment fish pieces together. */
+  pairId?: number;
   /** Whether this fish should draw with a highlighted variant */
   highlight?: boolean;
   /** Whether this fish has turned into a skeleton */


### PR DESCRIPTION
## Summary
- Add `pairId` to fish state and use it to spawn linked `grey_long` segments
- Ensure segment B syncs `vy` and nudges `vx` to follow segment A at `FISH_SIZE` separation
- Remove both segments when a `grey_long` is shot using `pairId`

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dd0acb730832bac648a713877205e