### PR TITLE
Add flash overlay for zombiefish skeleton conversion

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -259,8 +259,14 @@ export default function useGameEngine() {
     const { width, height } = cur.dims;
 
     // handle conversion flashes
+    const flashImg = getImg("fishFlashImg") as HTMLImageElement | undefined;
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d");
     cur.fish.forEach((f) => {
       if (f.pendingSkeleton) {
+        if (ctx && flashImg) {
+          ctx.drawImage(flashImg, f.x, f.y, FISH_SIZE, FISH_SIZE);
+        }
         f.flashTimer = (f.flashTimer || 0) - 1;
         if (f.flashTimer <= 0) {
           f.isSkeleton = true;
@@ -360,7 +366,7 @@ export default function useGameEngine() {
         f.y = Math.max(0, Math.min(f.y, height - FISH_SIZE));
       }
     });
-  }, [audio, makeText]);
+  }, [audio, makeText, getImg]);
 
   const spawnBubble = useCallback(() => {
     const { width, height } = state.current.dims;
@@ -613,6 +619,18 @@ export default function useGameEngine() {
           FISH_SIZE,
           FISH_SIZE
         );
+        if (f.pendingSkeleton) {
+          const flash = getImg("fishFlashImg") as HTMLImageElement;
+          if (flash) {
+            ctx.drawImage(
+              flash,
+              -FISH_SIZE / 2,
+              -FISH_SIZE / 2,
+              FISH_SIZE,
+              FISH_SIZE
+            );
+          }
+        }
         if (f.isSkeleton && f.hurtTimer > 0) {
           ctx.fillStyle = "rgba(255,0,0,0.5)";
           ctx.fillRect(-FISH_SIZE / 2, -FISH_SIZE / 2, FISH_SIZE, FISH_SIZE);


### PR DESCRIPTION
## Summary
- show flash effect on fish about to convert to skeleton

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dd0e02574832bb7140a044606f2a9