### PR TITLE
feat(zombiefish): track score in HUD and summary

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -73,6 +73,7 @@ export default function useGameEngine() {
     timer: GAME_TIME,
     shots: 0,
     hits: 0,
+    score: 0,
     accuracy: 0,
     cursor: DEFAULT_CURSOR,
     dims,
@@ -108,10 +109,12 @@ export default function useGameEngine() {
   const timerLabel = useRef<TextLabel | null>(null);
   const shotsLabel = useRef<TextLabel | null>(null);
   const hitsLabel = useRef<TextLabel | null>(null);
+  const scoreLabel = useRef<TextLabel | null>(null);
   const pausedLabel = useRef<TextLabel | null>(null);
   const gameoverShotsLabel = useRef<TextLabel | null>(null);
   const gameoverHitsLabel = useRef<TextLabel | null>(null);
   const gameoverTimeLabel = useRef<TextLabel | null>(null);
+  const gameoverScoreLabel = useRef<TextLabel | null>(null);
   const timeTextLabel = useRef<TextLabel | null>(null);
   const timeTextBounds = useRef({ x: 0, y: 0, width: 0, height: 0 });
 
@@ -121,6 +124,7 @@ export default function useGameEngine() {
     timer: GAME_TIME,
     shots: 0,
     hits: 0,
+    score: 0,
     accuracy: 0,
     cursor: DEFAULT_CURSOR,
   });
@@ -137,6 +141,7 @@ export default function useGameEngine() {
       timer: state.current.timer,
       shots: state.current.shots,
       hits: state.current.hits,
+      score: state.current.score,
       accuracy: state.current.accuracy,
       cursor,
     });
@@ -574,6 +579,7 @@ export default function useGameEngine() {
         );
         gameoverShotsLabel.current = makeStat(`SHOTS ${cur.shots}`, baseY + 40);
         gameoverHitsLabel.current = makeStat(`HITS ${cur.hits}`, baseY + 80);
+        gameoverScoreLabel.current = makeStat(`SCORE ${cur.score}`, baseY + 120);
       }
       if (!bestAccuracyLabel.current) {
         const best = Number(localStorage.getItem("bestAccuracy") || 0);
@@ -779,6 +785,7 @@ export default function useGameEngine() {
       timer: cur.timer,
       shots: cur.shots,
       hits: cur.hits,
+      score: cur.score,
       accuracy: cur.accuracy,
       cursor: cur.cursor,
     });
@@ -793,6 +800,7 @@ export default function useGameEngine() {
     cur.timer = GAME_TIME;
     cur.shots = 0;
     cur.hits = 0;
+    cur.score = 0;
     cur.accuracy = 0;
     cur.bubbles = [];
     cur.missParticles = [];
@@ -806,6 +814,10 @@ export default function useGameEngine() {
     seaweedOffsets.current.fill(0);
     seaGrassOffsets.current.fill(0);
     pausedLabel.current = null;
+    gameoverShotsLabel.current = null;
+    gameoverHitsLabel.current = null;
+    gameoverTimeLabel.current = null;
+    gameoverScoreLabel.current = null;
 
     const digitImgs = getImg("digitImgs") as Record<string, HTMLImageElement>;
     const digitHeight = digitImgs["0"]?.height || 0;
@@ -898,6 +910,29 @@ export default function useGameEngine() {
       },
       assetMgr
     );
+
+    const scoreText = newTextLabel(
+      {
+        text: "SCORE",
+        scale: 1,
+        fixed: true,
+        fade: false,
+        x: 16,
+        y: 16 + lineHeight * 3,
+      },
+      assetMgr
+    );
+    scoreLabel.current = newTextLabel(
+      {
+        text: cur.score.toString(),
+        scale: 1,
+        fixed: true,
+        fade: false,
+        x: 16 + labelWidth(scoreText),
+        y: 16 + lineHeight * 3,
+      },
+      assetMgr
+    );
     bubbleSpawnRef.current = 0;
 
     state.current.textLabels = [
@@ -907,6 +942,8 @@ export default function useGameEngine() {
       shotsLabel.current!,
       hitsText,
       hitsLabel.current!,
+      scoreText,
+      scoreLabel.current!,
     ];
     cur.cursor = DEFAULT_CURSOR;
     setUI({
@@ -914,6 +951,7 @@ export default function useGameEngine() {
       timer: cur.timer,
       shots: cur.shots,
       hits: cur.hits,
+      score: cur.score,
       accuracy: cur.accuracy,
       cursor: cur.cursor,
     });
@@ -936,6 +974,7 @@ export default function useGameEngine() {
     cur.timer = GAME_TIME;
     cur.shots = 0;
     cur.hits = 0;
+    cur.score = 0;
     cur.accuracy = 0;
     cur.conversions = 0;
     cur.fish = [];
@@ -951,9 +990,11 @@ export default function useGameEngine() {
     timerLabel.current = null;
     shotsLabel.current = null;
     hitsLabel.current = null;
+    scoreLabel.current = null;
     gameoverShotsLabel.current = null;
     gameoverHitsLabel.current = null;
     gameoverTimeLabel.current = null;
+    gameoverScoreLabel.current = null;
     state.current.textLabels = [];
     bubbleSpawnRef.current = 0;
     nextFishId.current = 1;
@@ -970,6 +1011,7 @@ export default function useGameEngine() {
       timer: cur.timer,
       shots: cur.shots,
       hits: cur.hits,
+      score: cur.score,
       accuracy: cur.accuracy,
       cursor: cur.cursor,
     });
@@ -1000,6 +1042,7 @@ export default function useGameEngine() {
           timer: cur.timer,
           shots: cur.shots,
           hits: cur.hits,
+          score: cur.score,
           accuracy: cur.accuracy,
           cursor: cur.cursor,
         });
@@ -1078,6 +1121,7 @@ export default function useGameEngine() {
           timer: cur.timer,
           shots: cur.shots,
           hits: cur.hits,
+          score: cur.score,
           accuracy: cur.accuracy,
           cursor: cur.cursor,
         });
@@ -1103,6 +1147,7 @@ export default function useGameEngine() {
             timer: cur.timer,
             shots: cur.shots,
             hits: cur.hits,
+            score: cur.score,
             accuracy: cur.accuracy,
             cursor: cur.cursor,
           });
@@ -1139,6 +1184,7 @@ export default function useGameEngine() {
             timer: cur.timer,
             shots: cur.shots,
             hits: cur.hits,
+            score: cur.score,
             accuracy: cur.accuracy,
             cursor: cur.cursor,
           });
@@ -1160,6 +1206,15 @@ export default function useGameEngine() {
           updateDigitLabel(hitsLabel.current, cur.hits);
           audio.play("hit");
           hit = true;
+          const scoreMap: Record<string, number> = {
+            brown: 50,
+            grey_long_a: 5,
+            grey_long_b: 5,
+          };
+          const base = f.isSkeleton ? 20 : scoreMap[f.kind] ?? 10;
+          const gain = base + cur.conversions;
+          cur.score += gain;
+          updateDigitLabel(scoreLabel.current, cur.score);
           if (f.kind === "brown") {
             cur.timer += TIME_BONUS_BROWN_FISH;
             updateDigitLabel(timerLabel.current, cur.timer, 2, ":");
@@ -1223,6 +1278,7 @@ export default function useGameEngine() {
         timer: cur.timer,
         shots: cur.shots,
         hits: cur.hits,
+        score: cur.score,
         accuracy: cur.accuracy,
         cursor: cur.cursor,
       });

--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -74,6 +74,8 @@ export interface GameUIState {
   shots: number;
   /** Total number of successful hits */
   hits: number;
+  /** Current score accumulated by the player */
+  score: number;
   /** Hit accuracy percentage */
   accuracy: number;
   /** Current cursor style */
@@ -82,6 +84,8 @@ export interface GameUIState {
 
 // Internal game state tracked by the engine
 export interface GameState extends GameUIState {
+  /** Current score accumulated by the player */
+  score: number;
   dims: Dims;
   /** Active fish currently in the scene */
   fish: Fish[];


### PR DESCRIPTION
## Summary
- add `score` to zombiefish game and UI state
- award score based on fish type and conversions
- display SCORE label during play and on game-over screen

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688df7a142d0832b8cae4cf60d1c9be3