### PR TITLE
Add warning audio and timer alert to Zombie Fish

### DIFF
--- a/src/games/zombiefish/hooks/useGameAudio.ts
+++ b/src/games/zombiefish/hooks/useGameAudio.ts
@@ -52,6 +52,10 @@ export function useGameAudio(): AudioMgr {
     tick.src = withBasePath("/audio/tick_002.ogg");
     tick.preload = "auto";
 
+    const warning = document.createElement("audio");
+    warning.src = withBasePath("/audio/warning.ogg");
+    warning.preload = "auto";
+
     return {
       shoot,
       hit,
@@ -62,6 +66,7 @@ export function useGameAudio(): AudioMgr {
       convert,
       pop,
       tick,
+      warning,
       bgm,
     };
   }, []);

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -81,6 +81,7 @@ export default function useGameEngine() {
     textLabels: [],
     missParticles: [],
     conversions: 0,
+    warningPlayed: false,
   });
 
   const nextFishId = useRef(1);
@@ -518,6 +519,10 @@ export default function useGameEngine() {
         frameRef.current = 0;
         cur.timer = Math.max(0, cur.timer - 1);
         updateDigitLabel(timerLabel.current, cur.timer, 2, ":");
+        if (cur.timer === 10 && !cur.warningPlayed) {
+          audio.play("warning");
+          cur.warningPlayed = true;
+        }
       }
 
       // check for game over once timer hits zero
@@ -796,6 +801,7 @@ export default function useGameEngine() {
     cur.accuracy = 0;
     cur.bubbles = [];
     cur.missParticles = [];
+    cur.warningPlayed = false;
 
     frameRef.current = 0;
     accuracyLabel.current = null;
@@ -942,6 +948,7 @@ export default function useGameEngine() {
     cur.cursor = DEFAULT_CURSOR;
     cur.bubbles = [];
     cur.missParticles = [];
+    cur.warningPlayed = false;
 
     accuracyLabel.current = null;
     bestAccuracyLabel.current = null;

--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -93,4 +93,6 @@ export interface GameState extends GameUIState {
   missParticles: MissParticle[];
   /** Total number of fish converted into skeletons */
   conversions: number;
+  /** Whether the ten-second warning has been played */
+  warningPlayed: boolean;
 }


### PR DESCRIPTION
## Summary
- load warning sound clip into Zombie Fish's audio manager
- play warning sound once when timer hits 10 seconds
- track/reset warning playback state in game engine and types

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: several unused variable errors in TitleSplash.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_688df7eb3684832b95f6db799a1f183a