### PR TITLE
Add surface background layer to zombiefish

### DIFF
--- a/src/games/zombiefish/hooks/useGameAssets.ts
+++ b/src/games/zombiefish/hooks/useGameAssets.ts
@@ -173,6 +173,16 @@ export function useGameAssets(): {
           ] || undefined
       );
 
+    // SURFACE & CLOUDS
+    assetRefs.current.surfaceImgs = [
+      loadImg("/assets/shooting-gallery/PNG/Stall/water1.png"),
+      loadImg("/assets/shooting-gallery/PNG/Stall/water2.png"),
+    ];
+    assetRefs.current.cloudImgs = [
+      loadImg("/assets/shooting-gallery/PNG/Stall/cloud1.png"),
+      loadImg("/assets/shooting-gallery/PNG/Stall/cloud2.png"),
+    ];
+
     // TERRAIN
     const topLetters = "abcdefgh".split("");
     const dirtNames = [


### PR DESCRIPTION
## Summary
- load surface and cloud assets for zombiefish
- introduce surface parallax offsets and speeds
- render surface layer between water and sand

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: unused vars in TitleSplash.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_688df7d7c2e0832bb6af77e6355eab68