### PR TITLE
feat(zombiefish): add wandering behavior

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -424,6 +424,19 @@ export default function useGameEngine() {
 
     });
 
+    // natural wandering for non-skeleton fish
+    cur.fish.forEach((f) => {
+      if (f.isSkeleton) return;
+      f.wanderTimer -= 1;
+      if (f.wanderTimer <= 0) {
+        const speed = Math.hypot(f.vx, f.vy) || 0;
+        const angle = Math.random() * Math.PI * 2;
+        f.vx = Math.cos(angle) * speed;
+        f.vy = Math.sin(angle) * speed;
+        f.wanderTimer = Math.floor(Math.random() * FPS) + FPS;
+      }
+    });
+
     // move fish with a slight oscillation and update their angle
     cur.fish.forEach((f) => {
       if (f.hurtTimer > 0) f.hurtTimer -= 1;
@@ -1298,6 +1311,7 @@ export default function useGameEngine() {
         angle: 0,
         health: k === "skeleton" ? 2 : 0,
         hurtTimer: 0,
+        wanderTimer: Math.floor(Math.random() * FPS) + FPS,
         isSkeleton: k === "skeleton",
         ...(groupId !== undefined ? { groupId } : {}),
         ...(highlight ? { highlight: true } : {}),
@@ -1325,6 +1339,7 @@ export default function useGameEngine() {
             angle: 0,
             health: kind === "skeleton" ? 2 : 0,
             hurtTimer: 0,
+            wanderTimer: Math.floor(Math.random() * FPS) + FPS,
             isSkeleton: kind === "skeleton",
             groupId,
             pairId,
@@ -1348,6 +1363,7 @@ export default function useGameEngine() {
             angle: 0,
             health: kind === "skeleton" ? 2 : 0,
             hurtTimer: 0,
+            wanderTimer: Math.floor(Math.random() * FPS) + FPS,
             isSkeleton: kind === "skeleton",
             groupId,
             pairId,

--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -21,6 +21,8 @@ export interface Fish {
   health: number;
   /** Frames remaining for the red flash after taking damage. */
   hurtTimer: number;
+  /** Frames remaining before the fish picks a new random heading. */
+  wanderTimer: number;
   /**
    * Optional identifier tying fish together when spawned in a group.
    * Special fish spawn without a groupId.


### PR DESCRIPTION
## Summary
- add `wanderTimer` to `Fish` type
- randomize fish heading when wander timer expires

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm install jest-environment-jsdom --save-dev` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: unused variable errors)*

------
https://chatgpt.com/codex/tasks/task_e_688df7d2126c832bb1611d58fa54c91c