### PR TITLE
Track fish hit counts per type

### DIFF
--- a/src/games/zombiefish/components/TitleSplash.tsx
+++ b/src/games/zombiefish/components/TitleSplash.tsx
@@ -1,16 +1,12 @@
-import React, { useEffect, useRef } from "react";
+import React, { useRef } from "react";
 
 import Box from "@mui/material/Box";
-import { drawTextLabels, newTextLabel } from "@/utils/ui";
-import type { AssetMgr } from "@/types/ui";
-import { FISH_SPEED_MIN, FISH_SPEED_MAX } from "../constants";
 
 export interface TitleSplashProps {
   onStart: () => void;
   titleSrc: string;
   backgroundColor: string;
   cursor: string;
-  getImg: AssetMgr["getImg"];
 }
 
 export const TitleSplash: React.FC<TitleSplashProps> = ({
@@ -18,7 +14,6 @@ export const TitleSplash: React.FC<TitleSplashProps> = ({
   titleSrc,
   backgroundColor,
   cursor,
-  getImg,
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animRef = useRef<number>(null);

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -81,6 +81,7 @@ export default function useGameEngine() {
     textLabels: [],
     missParticles: [],
     conversions: 0,
+    hitCounts: {},
   });
 
   const nextFishId = useRef(1);
@@ -574,6 +575,16 @@ export default function useGameEngine() {
         );
         gameoverShotsLabel.current = makeStat(`SHOTS ${cur.shots}`, baseY + 40);
         gameoverHitsLabel.current = makeStat(`HITS ${cur.hits}`, baseY + 80);
+
+        // create a label for each fish type hit
+        let y = baseY + 120;
+        Object.entries(cur.hitCounts)
+          .sort(([a], [b]) => a.localeCompare(b))
+          .forEach(([kind, count]) => {
+            const text = `${kind.replace(/_/g, " ")} ${count}`;
+            makeStat(text, y);
+            y += 40;
+          });
       }
       if (!bestAccuracyLabel.current) {
         const best = Number(localStorage.getItem("bestAccuracy") || 0);
@@ -938,6 +949,7 @@ export default function useGameEngine() {
     cur.hits = 0;
     cur.accuracy = 0;
     cur.conversions = 0;
+    cur.hitCounts = {};
     cur.fish = [];
     cur.cursor = DEFAULT_CURSOR;
     cur.bubbles = [];
@@ -1157,6 +1169,7 @@ export default function useGameEngine() {
           canvasY <= f.y + FISH_SIZE
         ) {
           cur.hits += 1;
+          cur.hitCounts[f.kind] = (cur.hitCounts[f.kind] || 0) + 1;
           updateDigitLabel(hitsLabel.current, cur.hits);
           audio.play("hit");
           hit = true;

--- a/src/games/zombiefish/types.ts
+++ b/src/games/zombiefish/types.ts
@@ -93,4 +93,6 @@ export interface GameState extends GameUIState {
   missParticles: MissParticle[];
   /** Total number of fish converted into skeletons */
   conversions: number;
+  /** Hit counts grouped by fish type */
+  hitCounts: Record<string, number>;
 }


### PR DESCRIPTION
## Summary
- track how many times each fish type is hit
- display per-type hit summary when game ends
- clean up unused imports in TitleSplash to satisfy lint

## Testing
- `npm run lint`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688df808a498832b8dd57786e7d585c7