### PR TITLE
Show final accuracy based on hits and shots

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -651,7 +651,8 @@ export default function useGameEngine() {
       // check for game over once timer hits zero
       if (cur.timer === 0) {
         cur.phase = "gameover";
-        finalAccuracy.current = Math.round(cur.accuracy);
+        finalAccuracy.current =
+          cur.shots > 0 ? Math.round((cur.hits / cur.shots) * 100) : 0;
         updateBestAccuracy(finalAccuracy.current);
         displayAccuracy.current = 0;
         audio.pause("bgm");


### PR DESCRIPTION
## Summary
- Derive game over accuracy directly from hits and shots.
- Maintain animated accuracy label that counts up to the final percentage.

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_688dffc5fad8832b9e6fe3dce0457fe2