### PR TITLE
Restart game from canvas click after game over

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -1231,23 +1231,8 @@ export default function useGameEngine() {
       e.preventDefault?.();
       const cur = state.current;
       if (cur.phase === "gameover") {
-        const canvas = canvasRef.current;
-        const lbl = accuracyLabel.current;
-        if (!canvas || !lbl) return;
-        const rect = canvas.getBoundingClientRect();
-        const x = ((e.clientX - rect.left) / rect.width) * cur.dims.width;
-        const y = ((e.clientY - rect.top) / rect.height) * cur.dims.height;
-        const w = lbl.imgs.reduce(
-          (sum, img) => sum + (img?.width || 0) * lbl.scale + 2,
-          0
-        );
-        const h = lbl.imgs.reduce(
-          (max, img) => Math.max(max, (img?.height || 0) * lbl.scale),
-          0
-        );
-        if (x >= lbl.x && x <= lbl.x + w && y >= lbl.y && y <= lbl.y + h) {
-          resetGame();
-        }
+        resetGame();
+        startSplash();
         return;
       }
 
@@ -1428,7 +1413,7 @@ export default function useGameEngine() {
         cursor: cur.cursor,
       });
     },
-    [audio, makeText, updateDigitLabel, resetGame]
+    [audio, makeText, updateDigitLabel, resetGame, startSplash]
   );
 
   // suppress context menu


### PR DESCRIPTION
## Summary
- Restart game when the canvas is clicked during game over by invoking reset and start logic

## Testing
- `npm test` *(fails: jest-environment-jsdom not found)*
- `npm install --save-dev jest-environment-jsdom` *(fails: 403 Forbidden)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dfff9c180832bb8a21816594efb62