### PR TITLE
feat: animate zombiefish individually

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -383,6 +383,18 @@ export default function useGameEngine() {
     const canvas = canvasRef.current;
     const ctx = canvas?.getContext("2d");
     cur.fish.forEach((f) => {
+      const frameMap = getImg(
+        f.isSkeleton ? "skeletonFrames" : "fishFrames"
+      ) as Record<string, HTMLImageElement[]>;
+      const frames = frameMap[f.kind as keyof typeof frameMap];
+      if (frames && frames.length > 0) {
+        f.frameCounter += 1;
+        if (f.frameCounter >= FISH_FRAME_DELAY) {
+          f.frameCounter = 0;
+          f.frame = (f.frame + 1) % frames.length;
+        }
+      }
+
       if (f.pendingSkeleton) {
         if (ctx && flashImg) {
           ctx.drawImage(flashImg, f.x, f.y, FISH_SIZE, FISH_SIZE);
@@ -855,11 +867,6 @@ export default function useGameEngine() {
         ) as Record<string, HTMLImageElement[]>;
         const frames = frameMap[f.kind as keyof typeof frameMap];
         if (!frames || frames.length === 0) return;
-        f.frameCounter++;
-        if (f.frameCounter >= FISH_FRAME_DELAY) {
-          f.frameCounter = 0;
-          f.frame = (f.frame + 1) % frames.length;
-        }
         const img = frames[f.frame];
         if (!img) return;
         ctx.save();


### PR DESCRIPTION
## Summary
- track an animation frame and counter for each fish
- step frames with a delay and render the current image

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688e049fe7b4832bac28eae5cae37b71