### PR TITLE
feat: tune zombiefish NES bgm

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -40,14 +40,19 @@ const FISH_FRAME_DELAY = 6;
 const MAX_SCHOOL_SIZE = 4;
 
 // NES-style jingle sequence for background music
-const NES_BGM_SEQUENCE = [
-  "jingles_NES00",
-  "jingles_NES05",
-  "jingles_NES07",
-  "jingles_NES12",
-  "jingles_NES07",
-  "jingles_NES05",
-];
+// Build a rising and falling "wave" pattern to feel bubbly and underwater.
+// We step up in thirds, crest, then wash back down and repeat.
+const NES_BGM_SEQUENCE = (() => {
+  const rise = [0, 3, 6, 9].map((n) =>
+    `jingles_NES${n.toString().padStart(2, "0")}`
+  );
+  const fall = [...rise].reverse();
+  const loop: string[] = [];
+  for (let i = 0; i < 2; i++) {
+    loop.push(...rise, "jingles_NES12", ...fall, "jingles_NES14");
+  }
+  return loop;
+})();
 // limit for how steep fish swim (cross-velocity relative to main)
 const MAX_FISH_INCLINE = 0.5;
 const SKELETON_CONVERT_DISTANCE = FISH_SIZE / 2;


### PR DESCRIPTION
## Summary
- add wavy NES-style bgm sequence for ZombieFish

## Testing
- `npm run lint`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_688f1887b3c0832bac31a54f8ab9fe2f