### PR TITLE
Fix grey_long fish spacing in ZombieFish game

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -466,7 +466,7 @@ export default function useGameEngine() {
       // synchronize vertical velocity
       b.vy = a.vy;
       // small corrective horizontal velocity to maintain spacing
-      const sign = b.x >= a.x ? 1 : -1;
+      const sign = a.vx >= 0 ? 1 : -1;
       const desiredX = a.x + FISH_SIZE * sign;
       const dx = desiredX - b.x;
       b.vx += dx * 0.05;


### PR DESCRIPTION
## Summary
- Correct multi-segment grey_long fish alignment by basing segment spacing on movement direction rather than relative positions

## Testing
- `npm run lint`
- `npm test` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f2749884c832b9ad42e0e6ff132fe