### PR TITLE
Limit fish spawning to reduce overcrowding

### DIFF
--- a/src/games/zombiefish/constants.ts
+++ b/src/games/zombiefish/constants.ts
@@ -27,7 +27,14 @@ export const FISH_SPEED_MAX = 3;
 export const SKELETON_SPEED = 2;
 
 // Maximum number of skeleton fish allowed simultaneously.
-export const MAX_SKELETONS = 20;
+// Lowered to reduce overall fish population on screen.
+export const MAX_SKELETONS = 10;
+
+// Maximum number of basic fish allowed simultaneously.
+export const MAX_FISH = 30;
+
+// Maximum number of special fish (brown, grey long, etc.) allowed at once.
+export const MAX_SPECIAL_FISH = 5;
 
 // Time adjustments when hitting special fish (in seconds).
 export const TIME_BONUS_BROWN_FISH = 3;

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -18,6 +18,8 @@ import {
   FISH_SPAWN_INTERVAL_MAX,
   SKELETON_SPEED,
   MAX_SKELETONS,
+  MAX_FISH,
+  MAX_SPECIAL_FISH,
   TIME_BONUS_BROWN_FISH,
   TIME_BONUS_GREY_LONG,
   DEFAULT_CURSOR,
@@ -1439,10 +1441,25 @@ export default function useGameEngine() {
     const isSpecial =
       specialSingles.includes(kind) || specialPairs.includes(kind);
 
-    const reuseFish = () => inactiveFish.current.pop() || ({} as Fish);
+    const specialsOnScreen = state.current.fish.filter((f) =>
+      specialSingles.includes(f.kind)
+    ).length;
+    const basicsOnScreen = state.current.fish.filter(
+      (f) => !f.isSkeleton && !specialSingles.includes(f.kind)
+    ).length;
 
-    if (isSpecial) count = 1;
+    if (isSpecial) {
+      const needed = specialPairs.includes(kind) ? 2 : 1;
+      if (specialsOnScreen + needed > MAX_SPECIAL_FISH) return [];
+      count = 1;
+    } else {
+      const available = MAX_FISH - basicsOnScreen;
+      if (available <= 0) return [];
+      count = Math.min(count, available);
+    }
     count = Math.min(count, MAX_SCHOOL_SIZE);
+
+    const reuseFish = () => inactiveFish.current.pop() || ({} as Fish);
 
     // decide spawning edge with a bias toward left/right entrances
     // omit top/bottom edges to avoid vertically swimming fish


### PR DESCRIPTION
## Summary
- reduce simultaneous skeleton fish to 10
- cap regular fish at 30 and special fish at 5 with spawn logic to skip spawns once caps are reached

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install jest-environment-jsdom` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_688f2a0a4cb4832bb8ac166af53ec888