### PR TITLE
Add bottom-right score display in Zombiefish

### DIFF
--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -179,6 +179,10 @@ export default function useGameEngine() {
     state.current.dims = dims;
   }, [dims]);
 
+  useEffect(() => {
+    updateScoreLabel(scoreLabel.current, state.current.score);
+  }, [dims, updateScoreLabel]);
+
   const syncCursor = useCallback((cursor: string) => {
     state.current.cursor = cursor;
     setUI({
@@ -256,6 +260,24 @@ export default function useGameEngine() {
       label.imgs = str.split("").map((ch) => digitImgs[ch]);
     },
     [getImg]
+  );
+
+  const updateScoreLabel = useCallback(
+    (label: TextLabel | null, value: number) => {
+      updateDigitLabel(label, value);
+      if (!label) return;
+      const width = label.imgs.reduce(
+        (w, img) => w + (img?.width || 0) * label.scale + 2,
+        0
+      );
+      const height = label.imgs.reduce(
+        (h, img) => Math.max(h, (img?.height || 0) * label.scale),
+        0
+      );
+      label.x = dims.width - width - 16;
+      label.y = dims.height - height - 16;
+    },
+    [updateDigitLabel, dims]
   );
 
   const updateFish = useCallback(() => {
@@ -885,8 +907,6 @@ export default function useGameEngine() {
     gameoverScoreLabel.current = null;
 
     const digitImgs = getImg("digitImgs") as Record<string, HTMLImageElement>;
-    const digitHeight = digitImgs["0"]?.height || 0;
-    const lineHeight = digitHeight + 8;
 
     audio.playSequence(NES_BGM_SEQUENCE, { loop: true });
 
@@ -923,30 +943,16 @@ export default function useGameEngine() {
         (timer?.py || 0) * 2,
     };
 
-    const scoreText = newTextLabel(
-      {
-        text: "SCORE",
-        scale: 1,
-        fixed: true,
-        fade: false,
-        x: 16,
-        y: 16 + lineHeight * 3,
-        py: STAT_LABEL_PY,
-      },
-      assetMgr
-    );
     scoreLabel.current = newTextLabel(
       {
         text: cur.score.toString(),
         scale: 1,
         fixed: true,
         fade: false,
-        x: 16 + labelWidth(scoreText),
-        y: 16 + lineHeight * 3,
-        py: STAT_LABEL_PY,
       },
       assetMgr
     );
+    updateScoreLabel(scoreLabel.current, cur.score);
 
     const pctImg = getImg("pctImg") as HTMLImageElement;
     const accLbl = newTextLabel(
@@ -971,7 +977,6 @@ export default function useGameEngine() {
 
     state.current.textLabels = [
       timerLabel.current!,
-      scoreText,
       scoreLabel.current!,
       accLbl,
     ];
@@ -1225,7 +1230,7 @@ export default function useGameEngine() {
           const base = f.isSkeleton ? 20 : scoreMap[f.kind] ?? 10;
           const gain = base + cur.conversions;
           cur.score += gain;
-          updateDigitLabel(scoreLabel.current, cur.score);
+          updateScoreLabel(scoreLabel.current, cur.score);
           if (f.kind === "brown") {
             cur.timer += TIME_BONUS_BROWN_FISH;
             updateDigitLabel(timerLabel.current, cur.timer, 2);


### PR DESCRIPTION
## Summary
- render a fixed score label using `newTextLabel` in the Zombiefish engine
- update score digits and keep label anchored to the bottom-right
- remove accidental Warbirds score label changes

## Testing
- `npm test` (fails: jest-environment-jsdom cannot be found; install attempt blocked by 403)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689003666754832b8583bcd2f0fd81df